### PR TITLE
RAILS_DEFAULT_LOGGER deprecation

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -18,6 +18,8 @@ module Delayed
     
     self.logger = if defined?(Merb::Logger)
       Merb.logger
+    elsif defined?(Rails)
+      Rails.logger
     elsif defined?(RAILS_DEFAULT_LOGGER)
       RAILS_DEFAULT_LOGGER
     end


### PR DESCRIPTION
Two-line fix to avoid a rasil3 deprecation message.
