### PR TITLE
Separate log files

### DIFF
--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -91,7 +91,8 @@ module Delayed
         end
       end
       
-      Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))
+      log_name = worker_name || 'delayed_job'
+      Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', "#{log_name}.log"))
       Delayed::Worker.backend.after_fork
       
       worker = Delayed::Worker.new(@options)


### PR DESCRIPTION
Just a small change to make script/delayed_job log to separate files if you run multiple workers... by default, uses log/delayed_job.log... if you use -n, you'll get delayed_job.N.log, if you use -i, you'll get delayed_job.<identifier>.log
