### PR TITLE
Changed the way error messages are composed, to prevent the delayed_job worker to crash if an error with a nil message is raised

### DIFF
--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -345,6 +345,7 @@ shared_examples_for 'a delayed_job backend' do
           Delayed::Worker.max_run_time = old_max_run_time
         end
       end
+      
     end
 
     context "worker prioritization" do
@@ -432,6 +433,13 @@ shared_examples_for 'a delayed_job backend' do
         @job.reload
         
         (Delayed::Job.db_time_now + 99.minutes - @job.run_at).abs.should < 1
+      end
+      
+      it "should not fail when the triggered error doesn't have a message" do
+        error_with_nil_message = StandardError.new
+        error_with_nil_message.stub!(:message).and_return nil
+        @job.stub!(:invoke_job).and_raise error_with_nil_message
+        lambda{@worker.run(@job)}.should_not raise_error
       end
     end
 

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -152,7 +152,7 @@ module Delayed
   protected
     
     def handle_failed_job(job, error)
-      job.last_error = error.message + "\n" + error.backtrace.join("\n")
+      job.last_error = "{#{error.message}\n#{error.backtrace.join('\n')}"
       say "#{job.name} failed with #{error.class.name}: #{error.message} - #{job.attempts} failed attempts", Logger::ERROR
       reschedule(job)
     end


### PR DESCRIPTION
(Pasted from the commit comment)

Changed the way the error message is composed when a job fails. Whith the previous implementation, if the raised error has a nil message, it will fail with a `<NoMethodError: undefined method '+' for nil:NilClass>`. Now it is using normal Ruby interpolation that will default to an empty String with nil messages.

Having an exception with a nil message is not a normal Ruby behaviour (Exceptions usually default to its class name when no message is provided), but it is possible. I am experiencing this problem because I am using the Ruby EDAM implementation of a commercial API, that doesn't set a message for its errors. The problem with delayed_job is quite serious, since it makes the jobs worker to crash completely (it kills the process).
