### PR TITLE
V2.0

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -19,7 +19,7 @@ This version is for Rails 2.x only.  For rails 3 support, install delayed_job 2.
 To install as a gem, add the following to @config/environment.rb@:
 
 <pre>
-config.gem 'delayed_job'
+config.gem 'delayed_job', :version => "= 2.0.4"
 </pre>
 
 Rake tasks are not automatically loaded from gems, so you'll need to add the following to your Rakefile:
@@ -35,7 +35,7 @@ end
 To install as a plugin:
 
 <pre>
-script/plugin install git://github.com/collectiveidea/delayed_job.git
+script/plugin install git://github.com/collectiveidea/delayed_job.git -r v2.0 
 </pre>
 
 After delayed_job is installed, you will need to setup the backend.


### PR DESCRIPTION
Hello, I've updated the readme file with the branch/version installation information for delayed_job 2.0.4 and Rails 2.x applications.

thanks!
