### PR TITLE
2.0 Sleep Delay Backport

### DIFF
--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -44,8 +44,9 @@ module Delayed
         opts.on('-m', '--monitor', 'Start monitor process.') do
           @monitor = true
         end
-        
-
+        opts.on('--sleep-delay N', "Amount of time to sleep when no jobs are found") do |n|
+          @options[:sleep_delay] = n
+        end
       end
       @args = opts.parse!(args)
     end

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -49,6 +49,7 @@ module Delayed
       @quiet = options[:quiet]
       self.class.min_priority = options[:min_priority] if options.has_key?(:min_priority)
       self.class.max_priority = options[:max_priority] if options.has_key?(:max_priority)
+      self.class.sleep_delay = options[:sleep_delay] if options.has_key?(:sleep_delay)
     end
 
     # Every worker has a unique name which by default is the pid of the process. There are some


### PR DESCRIPTION
Backports the sleep_delay command line option patch that was already accepted in 2.1.
