### PR TITLE
v2.0 reschedule_at backport

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -71,6 +71,12 @@ module Delayed
         self.locked_at    = nil
         self.locked_by    = nil
       end
+    
+      def reschedule_at
+        payload_object.respond_to?(:reschedule_at) ? 
+          payload_object.reschedule_at(self.class.db_time_now, attempts) :
+          self.class.db_time_now + (attempts ** 4) + 5
+      end
       
     private
 
@@ -99,13 +105,13 @@ module Delayed
       def attempt_to_load(klass)
          klass.constantize
       end
-
+      
     protected
 
       def set_default_run_at
         self.run_at ||= self.class.db_time_now
-      end
-    
+      end    
+
     end
   end
 end

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -132,8 +132,7 @@ module Delayed
     # Uses an exponential scale depending on the number of failed attempts.
     def reschedule(job, time = nil)
       if (job.attempts += 1) < self.class.max_attempts
-        time ||= Job.db_time_now + (job.attempts ** 4) + 5
-        job.run_at = time
+        job.run_at = time || job.reschedule_at
         job.unlock
         job.save!
       else


### PR DESCRIPTION
2.1 allows the payload object to define #reschedule_at(time, attempts).  This patch backports that behavior to 2.0.
