### PR TITLE
Issue with Railtie and loading ActionMailer too early

### DIFF
--- a/lib/delayed/performable_mailer.rb
+++ b/lib/delayed/performable_mailer.rb
@@ -1,4 +1,4 @@
-require 'action_mailer'
+require 'mail'
 
 module Delayed
   class PerformableMailer < PerformableMethod
@@ -6,11 +6,11 @@ module Delayed
       object.send(method_name, *args).deliver
     end
   end
-end
 
-ActionMailer::Base.class_eval do
-  def self.delay(options = {})
-    Delayed::DelayProxy.new(Delayed::PerformableMailer, self, options)
+  module DelayMail
+    def delay(options = {})
+      DelayProxy.new(PerformableMailer, self, options)
+    end
   end
 end
 

--- a/lib/delayed/railtie.rb
+++ b/lib/delayed/railtie.rb
@@ -5,6 +5,10 @@ module Delayed
   class Railtie < Rails::Railtie
     initializer :after_initialize do
       Delayed::Worker.guess_backend
+
+      ActiveSupport.on_load(:action_mailer) do
+        ActionMailer::Base.send(:extend, Delayed::DelayMail)
+      end
     end
 
     rake_tasks do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'bundler/setup'
 require 'rspec'
 require 'logger'
 
+require 'rails'
 require 'active_record'
 require 'action_mailer'
 
@@ -13,7 +14,6 @@ require 'delayed/backend/shared_spec'
 
 Delayed::Worker.logger = Logger.new('/tmp/dj.log')
 ENV['RAILS_ENV'] = 'test'
-require 'rails'
 
 config = YAML.load(File.read('spec/database.yml'))
 ActiveRecord::Base.configurations = {'test' => config['mysql']}
@@ -53,3 +53,6 @@ Delayed::Worker.backend = :active_record
 
 # Add this directory so the ActiveSupport autoloading works
 ActiveSupport::Dependencies.autoload_paths << File.dirname(__FILE__)
+
+# Add this to simulate Railtie initializer being executed
+ActionMailer::Base.send(:extend, Delayed::DelayMail)


### PR DESCRIPTION
Hi,

Currently DelayedJob has an issue caused by referencing ActionMailer::Base. Opening "ActionMailer::Base" on performable_mailer causes some ActionMailer initialization code to be run, making it ignore configuration set on initializers.

This pull request fix it by moving the code to a initializer on the Railtie. However, I couldn't get the Railtie code to run on the spec so I had to make a dirty hack. I would appreciate some help on working on a better patch :)

Thanks!
