### PR TITLE
Allow job payloads to implement #max_attempts

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -109,7 +109,11 @@ module Delayed
           payload_object.reschedule_at(self.class.db_time_now, attempts) :
           self.class.db_time_now + (attempts ** 4) + 5
       end
-
+      
+      def max_attempts
+        payload_object.max_attempts if payload_object.respond_to?(:max_attempts)
+      end
+      
     protected
 
       def set_default_run_at

--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -271,6 +271,21 @@ shared_examples_for 'a delayed_job backend' do
       @job.id.should_not be_nil
     end
   end
+  
+  context "max_attempts" do
+    before(:each) do
+      @job = described_class.enqueue SimpleJob.new
+    end
+    
+    it 'should not be defined' do
+      @job.max_attempts.should be_nil
+    end
+    
+    it 'should use the max_retries value on the payload when defined' do
+      @job.payload_object.stub!(:max_attempts).and_return(99)
+      @job.max_attempts.should == 99
+    end 
+  end
 
   describe "yaml serialization" do
     it "should reload changed attributes" do
@@ -382,7 +397,7 @@ shared_examples_for 'a delayed_job backend' do
 
           it "should run that hook" do
             @job.payload_object.should_receive :failure
-            Delayed::Worker.max_attempts.times { worker.reschedule(@job) }
+            worker.reschedule(@job)
           end
         end
 

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -132,7 +132,7 @@ module Delayed
     # Reschedule the job in the future (when a job fails).
     # Uses an exponential scale depending on the number of failed attempts.
     def reschedule(job, time = nil)
-      if (job.attempts += 1) < self.class.max_attempts
+      if (job.attempts += 1) < max_attempts(job)
         time ||= job.reschedule_at
         job.run_at = time
         job.unlock
@@ -157,6 +157,10 @@ module Delayed
       logger.add level, "#{Time.now.strftime('%FT%T%z')}: #{text}" if logger
     end
 
+    def max_attempts(job)
+      job.max_attempts || self.class.max_attempts
+    end
+    
   protected
 
     def handle_failed_job(job, error)

--- a/spec/sample_jobs.rb
+++ b/spec/sample_jobs.rb
@@ -25,8 +25,8 @@ class LongRunningJob
 end
 
 class OnPermanentFailureJob < SimpleJob
-  def failure
-  end
+  def failure; end
+  def max_attempts; 1; end
 end
 
 module M


### PR DESCRIPTION
This patch allows job payloads to override the worker's configured max_attempts by implementing a #max_attempts method.
