### PR TITLE
Delayed::DeserializationError exception fixed for non-default AR primary_key

### DIFF
--- a/lib/delayed/serialization/active_record.rb
+++ b/lib/delayed/serialization/active_record.rb
@@ -2,7 +2,7 @@ class ActiveRecord::Base
   yaml_as "tag:ruby.yaml.org,2002:ActiveRecord"
 
   def self.yaml_new(klass, tag, val)
-    klass.find(val['attributes']['id'])
+    klass.find(val['attributes'][klass.primary_key])
   rescue ActiveRecord::RecordNotFound
     raise Delayed::DeserializationError
   end

--- a/spec/active_record_ext_spec.rb
+++ b/spec/active_record_ext_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe ActiveRecord do
+  it 'should load classes with non-default primary key' do
+    lambda {
+      YAML.load(Story.create.to_yaml)
+    }.should_not raise_error    
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,13 +36,14 @@ ActiveRecord::Schema.define do
 
   add_index :delayed_jobs, [:priority, :run_at], :name => 'delayed_jobs_priority'
 
-  create_table :stories, :force => true do |table|
+  create_table :stories, :primary_key => :story_id, :force => true do |table|
     table.string :text
   end
 end
 
 # Purely useful for test cases...
 class Story < ActiveRecord::Base
+  set_primary_key :story_id
   def tell; text; end
   def whatever(n, _); tell*n; end
 


### PR DESCRIPTION
Here is the fix for the case when we're using non-default primary key (e.g. issue_id)
It doesn't throw Delayed::DeserializationError exception anymore when you're trying to load serialized object without "id" attribute.
I think the commit should also fix the next issue: https://github.com/collectiveidea/delayed_job_mongoid/issues/issue/5
