### PR TITLE
Load by primary key

### DIFF
--- a/lib/delayed/serialization/active_record.rb
+++ b/lib/delayed/serialization/active_record.rb
@@ -2,7 +2,7 @@ class ActiveRecord::Base
   yaml_as "tag:ruby.yaml.org,2002:ActiveRecord"
 
   def self.yaml_new(klass, tag, val)
-    klass.find(val['attributes']['id'])
+    klass.find(val['attributes'][klass.primary_key])
   rescue ActiveRecord::RecordNotFound
     raise Delayed::DeserializationError
   end


### PR DESCRIPTION
An ActiveRecord model doesn't necessarily use id for the primary key. Call .primary_key on the class instead of assuming 'id'.
