### PR TITLE
Added support for multiple concurrent daemons as long as they are in different environments.

### DIFF
--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -60,7 +60,6 @@ module Delayed
       
       dir = @options[:pid_dir]
       Dir.mkdir(dir) unless File.exists?(dir)
-      p Rails.env
       base_process_name = "delayed_job.#{Rails.env}"
       if @worker_count > 1 && @options[:identifier]
         raise ArgumentError, 'Cannot specify both --number-of-workers and --identifier'
@@ -69,7 +68,7 @@ module Delayed
         run_process(process_name, dir)
       else
         worker_count.times do |worker_index|
-          process_name = worker_count == 1 ? base_process_name : "#{base_process_name}.#{Rails.env}.#{worker_index}"
+          process_name = worker_count == 1 ? base_process_name : "#{base_process_name}.#{worker_index}"
           run_process(process_name, dir)
         end
       end


### PR DESCRIPTION
This is particularly useful for test and development environments. I want my development daemon running all day. I want my test daemon to fire up on demand. The two should not conflict. This allows that, by appending the environment to the process name.

For my current project, I also have multiple parallel production environments, one for each client, with completely isolated databases. Each environment should have its own daemon.

I saw no tests for daemons. If you would like me to add those tests, please tell me how you would like it to be tested.
