### PR TITLE
Psych fix: handle Class#to_yaml already being removed.

### DIFF
--- a/lib/delayed/yaml_ext.rb
+++ b/lib/delayed/yaml_ext.rb
@@ -27,7 +27,7 @@ end
 
 class Class
   yaml_as "tag:ruby.yaml.org,2002:class"
-  remove_method :to_yaml # use Module's to_yaml
+  remove_method :to_yaml rescue nil # use Module's to_yaml
 end
 
 class Struct


### PR DESCRIPTION
Fixes #199 by rescuing NameError on attempt to remove_method :to_yaml from Class.
