### PR TITLE
Psych (YAML) workaround

### DIFF
--- a/lib/delayed/yaml_ext.rb
+++ b/lib/delayed/yaml_ext.rb
@@ -2,7 +2,7 @@
 # Classes, Modules and Structs
 
 require 'yaml'
-YAML::ENGINE.yamler = "syck"
+YAML::ENGINE.yamler = "syck" if defined?(YAML::ENGINE)
 
 class Module
   yaml_as "tag:ruby.yaml.org,2002:module"


### PR DESCRIPTION
See #199 for more information.

Psych is gradually becoming the default YAML parser in Ruby 1.9, but delayed_job does not like it at all.  With RubyGems 1.5 and Bundler 1.0.10 loading Psych, it's getting harder to avoid.

If Psych is loaded before delayed_job, delayed_job fails to `remove_method :to_yaml` raising a NameError.  The first commit, by benhoskings, guards against this.

The second commit sets `YAML::ENGINE.yamler = "syck"` so that delayed_job works properly if something has already set the yamler to "psych".

Tested in Ruby 1.9.2-p136 and Ruby 1.8.7-p330 with the delayed_job test suite and with a Rails 3.0.3 application under Bundler 1.0.10.

Cheers,
Paul

PS: sorry about the earlier pull request that wasn't quite there.
