### PR TITLE
Prepend Rails.root to worker process names

### DIFF
--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -47,6 +47,9 @@ module Delayed
         opts.on('--sleep-delay N', "Amount of time to sleep when no jobs are found") do |n|
           @options[:sleep_delay] = n
         end
+        opts.on('-p', '--prefix NAME', "String to be prefixed to worker process names") do |prefix|
+          @options[:prefix] = prefix
+        end
       end
       @args = opts.parse!(args)
     end
@@ -76,6 +79,7 @@ module Delayed
     
     def run_process(process_name, dir)
       Daemons.run_proc(process_name, :dir => dir, :dir_mode => :normal, :monitor => @monitor, :ARGV => @args) do |*args|
+        $0 = File.join @options[:prefix], process_name if @options[:prefix]
         run process_name
       end
     end


### PR DESCRIPTION
I'm using script/delayed_job to manage my workers. The processes that it spawns are named delayed_job.0, delayed_job.1 etc. This is confusing when having more than one Rails application based on delayed_job running on the same box.

This patch prepends the path to the Rails application to the process names, e.g. delayed_job.0 becomes /prod/apps/seven.alg/delayed_job.0

I didn't find a spec for Command, but I did make sure that all the specs still run. I tested by running script/delayed_job -n 4 start, doing a ps -ax to make sure that the process names are right, then running script/delayed_job stop to make sure that the workers still stop.

Thank you for the awesome work keeping delayed_job up to date, and please let me know if there's anything I can do to get the patch accepted!
