### PR TITLE
Hooks don't get called when Delayed::Worker.delay_jobs = false

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -29,7 +29,7 @@ module Delayed
               job.hook(:enqueue)
             end
           else
-            job = Delayed::Job.create :payload_object => options[:payload_object]
+            job = Delayed::Job.new :payload_object => options[:payload_object]
             job.invoke_job
           end
         end


### PR DESCRIPTION
As title sais, when Delayed::Worker.delay_jobs = false, no hook gets called. This one-line pull request fixes the problem.
