### PR TITLE
Added :completed hook

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -121,6 +121,7 @@ module Delayed
         job.destroy
       end
       say "#{job.name} completed after %.4f" % runtime
+      job.hook(:completed)
       return true  # did work
     rescue DeserializationError => error
       job.last_error = "{#{error.message}\n#{error.backtrace.join('\n')}"


### PR DESCRIPTION
Hi,

Thanks for the great software. I added a :complete hook
The reason for this is the :after and :success dont occur completely after the job is complete. The job is still in the database and hasn't been deleted at either of those two points. If you want to add a hook for example autoscaling on heroku, you need to know that the database is actually empty before stopping the workers
It is a very minor change that you might be interested in incorporating 
