### PR TITLE
Yaml for Date

### DIFF
--- a/lib/delayed/yaml_ext.rb
+++ b/lib/delayed/yaml_ext.rb
@@ -4,6 +4,14 @@
 require 'yaml'
 YAML::ENGINE.yamler = "syck" if defined?(YAML::ENGINE)
 
+class Date
+  def to_yaml( opts={} )
+    YAML::quick_emit( self, opts ) do |out|
+      out.scalar( "tag:yaml.org,2002:timestamp", self.to_s(:db), :plain )
+    end
+  end
+end
+
 class Module
   yaml_as "tag:ruby.yaml.org,2002:module"
 


### PR DESCRIPTION
DelayedJob will fail to parse YAML with a Date in it if we need to redefine the default date format, like below:
    Date::DATE_FORMATS[:default] = "%m/%d/%Y"

I've included the fix, which just reopen the Date class and use to_s(:db) instead of to_s(:default)
