### PR TITLE
Requiring missing ActiveSupport core extension

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -2,6 +2,7 @@ require 'timeout'
 require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/class/attribute_accessors'
 require 'active_support/core_ext/kernel'
+require 'active_support/core_ext/enumerable'
 require 'logger'
 
 module Delayed


### PR DESCRIPTION
Require the Enumerable core extension from ActiveSupport. This is required to use the sum method on the result array on line 82.

Before this, the following error would be raised when running Delayed::Worker.new.start:

```
undefined method `sum' for [0, 0]:Array
/Users/watson/.rvm/gems/ruby-1.9.2-p180/gems/delayed_job-2.1.4/lib/delayed/worker.rb:81:in `block in start'
/Users/watson/.rvm/gems/ruby-1.9.2-p180/gems/delayed_job-2.1.4/lib/delayed/worker.rb:74:in `loop'
/Users/watson/.rvm/gems/ruby-1.9.2-p180/gems/delayed_job-2.1.4/lib/delayed/worker.rb:74:in `start'
```
