### PR TITLE
YAML loading should work even if AR object is not in default scope

### DIFF
--- a/lib/delayed/serialization/active_record.rb
+++ b/lib/delayed/serialization/active_record.rb
@@ -2,7 +2,7 @@ class ActiveRecord::Base
   yaml_as "tag:ruby.yaml.org,2002:ActiveRecord"
 
   def self.yaml_new(klass, tag, val)
-    klass.find(val['attributes'][klass.primary_key])
+    klass.unscoped.find(val['attributes'][klass.primary_key])
   rescue ActiveRecord::RecordNotFound
     raise Delayed::DeserializationError
   end

--- a/spec/active_record_ext_spec.rb
+++ b/spec/active_record_ext_spec.rb
@@ -6,4 +6,10 @@ describe ActiveRecord do
       YAML.load(Story.create.to_yaml)
     }.should_not raise_error    
   end
+
+  it 'should load classes even if not in default scope' do
+    lambda {
+      YAML.load(Story.create(:scoped => false).to_yaml)
+    }.should_not raise_error    
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define do
 
   create_table :stories, :primary_key => :story_id, :force => true do |table|
     table.string :text
+    table.boolean :scoped, :default => true
   end
 end
 
@@ -46,6 +47,7 @@ class Story < ActiveRecord::Base
   set_primary_key :story_id
   def tell; text; end
   def whatever(n, _); tell*n; end
+  default_scope where(:scoped => true)
 
   handle_asynchronously :whatever
 end


### PR DESCRIPTION
DJ doesn't work if your AR object is not in default scope while loaded from YAML. It was an issue for us since some objects could or couldn't be in default scope while processed with a delayed job which was unrelated to object's default scope.

Tests included.
