### PR TITLE
Added ability for enqueue hook to modify the job object before being saved.

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -25,8 +25,9 @@ module Delayed
           end
 
           if Delayed::Worker.delay_jobs
-            self.create(options).tap do |job|
+            self.new(options).tap do |job|
               job.hook(:enqueue)
+              job.save
             end
           else
             Delayed::Job.new(:payload_object => options[:payload_object]).tap do |job|

--- a/spec/active_record_job_spec.rb
+++ b/spec/active_record_job_spec.rb
@@ -33,4 +33,12 @@ describe Delayed::Backend::ActiveRecord::Job do
       Delayed::Backend::ActiveRecord::Job.after_fork
     end
   end
+  
+  describe "enqueue" do
+    it "should allow enqueue hook to modify job at DB level" do
+      later = described_class.db_time_now + 20.minutes
+      job = described_class.enqueue :payload_object => EnqueueJobMod.new
+      Delayed::Backend::ActiveRecord::Job.find(job.id).run_at.should be_within(1).of(later)
+    end
+  end
 end

--- a/spec/sample_jobs.rb
+++ b/spec/sample_jobs.rb
@@ -67,3 +67,9 @@ class CallbackJob
     self.class.messages << 'failure'
   end
 end
+
+class EnqueueJobMod < SimpleJob
+  def enqueue(job)
+    job.run_at = 20.minutes.from_now
+  end
+end


### PR DESCRIPTION
The enqueue hook was programmed to pass in the job object already, but any modification of the object was neglected because it was not saved to the database. The supplied changes wait to write the object to the DB until after the enqueue hook is called.

This saves 1 DB write for people who want to use this ability while not adding any cost to users who don't. If you approve of this modification, I can also add it to the 3.0 branch.
