### PR TITLE
Daemon logging control

### DIFF
--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -50,6 +50,9 @@ module Delayed
         opts.on('-p', '--prefix NAME', "String to be prefixed to worker process names") do |prefix|
           @options[:prefix] = prefix
         end
+        opts.on('--log_output', 'Send STDERR and STDOUT to a log file for daemon process.') do
+          @options[:log_output] = true
+        end
       end
       @args = opts.parse!(args)
     end
@@ -78,7 +81,7 @@ module Delayed
     end
     
     def run_process(process_name, dir)
-      Daemons.run_proc(process_name, :dir => dir, :dir_mode => :normal, :monitor => @monitor, :ARGV => @args) do |*args|
+      Daemons.run_proc(process_name, :dir => dir, :dir_mode => :normal, :log_output => @options[:log_output], :monitor => @monitor, :ARGV => @args) do |*args|
         $0 = File.join(@options[:prefix], process_name) if @options[:prefix]
         run process_name
       end


### PR DESCRIPTION
Add command line flag to enable redirecting STDERR and STDOUT of daemon process to a log file. 

We were having some issues with our delayed_job worker dying, but we weren't seeing any log messages explaining why.  I suspected that we were losing some helpful information in STDERR which is redirected to /dev/null in the daemonizing process.  Fortunately, the daemons gem provides an option to redirect STDERR and STDOUT to a log file that is dropped by default into the pids directory.  This patch adds a command line flag to enable the option when invoking Daemons.run_proc.

By default, the behavior remains the same as current versions when starting delayed_job.  But now if you invoke delayed job like so:

```
./script/delayed_job --log_output start
```

The daemons gem will write STDOUT and STDERR to tmp/pids/delayed_job.output
