### PR TITLE
Worker process exits if the job failure callback raises an exception.

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -145,7 +145,7 @@ module Delayed
     end
 
     def failed(job)
-      job.hook(:failure)
+      job.hook(:failure) rescue nil
       if job.respond_to?(:on_permanent_failure)
         warn "[DEPRECATION] The #on_permanent_failure hook has been renamed to #failure."
       end

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -34,4 +34,15 @@ describe Delayed::Worker do
       lambda { Delayed::Worker.guess_backend }.should_not change { Delayed::Worker.backend }
     end
   end
+
+  describe 'failed' do
+    before do
+      @worker = Delayed::Worker.new
+      @job = Delayed::Job.new
+      @job.should_receive(:hook).with(:failure) {raise 'failure callback raised'}
+    end
+    it 'should trap exceptions' do
+      expect {@worker.failed(@job)}.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
This change traps exceptions raised while invoking the job failure callback to prevent the worker process from exiting.  Since this callback is invoked prior to permanently failing the job, it seems reasonable to just swallow the exception and remove the job.
