### PR TITLE
Fix for YAML.load + active_record

### DIFF
--- a/lib/delayed/serialization/active_record.rb
+++ b/lib/delayed/serialization/active_record.rb
@@ -4,10 +4,23 @@ class ActiveRecord::Base
   def self.yaml_new(klass, tag, val)
     klass.unscoped.find(val['attributes'][klass.primary_key])
   rescue ActiveRecord::RecordNotFound
-    raise Delayed::DeserializationError
+    foo = klass.new
+    val['attributes'].each do |k, v|
+      meth = "#{k}="
+      foo.send(meth, v) if foo.respond_to?(meth)
+    end
+    foo
   end
+
 
   def to_yaml_properties
     ['@attributes']
   end
+
+  def ghost_dj?
+    false if self.class.find(self.id)
+  rescue ActiveRecord::RecordNotFound
+    true
+  end
+
 end

--- a/spec/active_record_spec.rb
+++ b/spec/active_record_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe ActiveRecord::Base do
+  describe "yaml_new" do
+
+    before do
+      @foo = Story.create(:text => "Hello World")
+      @bar = @foo.to_yaml
+    end
+
+    it "should load YAML representations of records that exist in the database" do
+      baz = YAML.load(@bar)
+      baz.should == @foo
+    end
+
+    it "should load YAML representation of records that do not exist in the database" do
+      @foo.destroy
+      baz = YAML.load(@bar)
+      baz.should == @foo
+    end
+
+    it "Should load YAML respresentation of a record that has never existed in the database" do
+      foo = "--- !ruby/ActiveRecord:Story \nattributes: \n  text: Hello World\n  id: 9001\n"
+      bar = YAML.load(foo)
+      bar.class.should == Story
+      bar.text.should == "Hello World"
+      bar.id.should == 9001
+    end
+
+  end
+end


### PR DESCRIPTION
Adding ghost? and ghost_dj? methods, so that trying to run a job on an activerecord object that has been deleted will raise a deserialization error, while fixing the YAML.load behavior

This patch does not touch or break any existing specs, while resolving the problem I had.

I (and others) have been unable to load records into rails using yaml, because delayed_job has overriden the functionality of YAML.  

This patch restores the functionality of YAML.load while maintaining the deserialization error that allows DJ to fast fail jobs that represent AR objects that have been deleted.  

This pull request is the culmination of https://github.com/collectiveidea/delayed_job/pull/231 
