### PR TITLE
Config option to have workers raise SignalException on SIGTERM and SIGINT

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -24,6 +24,11 @@ module Delayed
     cattr_accessor :destroy_failed_jobs
     self.destroy_failed_jobs = true
 
+    # By default, Signalt SIGINT and SIGTERM set @exit, and the worker exits upon completion of the current job.
+    # If you want to do some cleanup before terminating, set this to true
+    cattr_accessor :raise_signal_exceptions
+    self.raise_signal_exceptions = false
+
     self.logger = if defined?(Rails)
       Rails.logger
     elsif defined?(RAILS_DEFAULT_LOGGER)
@@ -103,8 +108,13 @@ module Delayed
     end
         
     def start
-      trap('TERM') { say 'Exiting...'; stop }
-      trap('INT')  { say 'Exiting...'; stop }
+      if self.raise_signal_exceptions
+        trap('TERM') { stop; raise SignalException.new('SIGTERM') }
+        trap('INT')  { stop; raise SignalException.new('SIGINT')  }
+      else
+        trap('TERM') { say 'Exiting...'; stop }
+        trap('INT')  { say 'Exiting...'; stop }
+      end
 
       say "Starting job worker"
       


### PR DESCRIPTION
This adds the config option `Delayed::Worker.raise_signal_exceptions`, changing the workers behavior on receiving SIGTERM and SIGINT (but defaulting to the current behavior).

Currently, they set `@exit`, and terminate after the current job completes. With this option enabled, they'll do the same thing, but also raise the appropriate SignalException.
#### Relevance

On heroku, when workers are being terminated or restarted for any reason (and unix in general, on shutdown - http://en.wikipedia.org/wiki/SIGTERM), a SIGTERM is sent, followed a few seconds later by a SIGKILL. If the worker is performing a task that takes longer than those few seconds, it will get hard-killed, not running any cleanup exception handling that may be necessary.
