### PR TITLE
Newline fix in job.last_error

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -124,7 +124,7 @@ module Delayed
       say "#{job.name} completed after %.4f" % runtime
       return true  # did work
     rescue DeserializationError => error
-      job.last_error = "{#{error.message}\n#{error.backtrace.join('\n')}"
+      job.last_error = "{#{error.message}\n#{error.backtrace.join("\n")}"
       failed(job)
     rescue Exception => error
       handle_failed_job(job, error)
@@ -166,7 +166,7 @@ module Delayed
   protected
 
     def handle_failed_job(job, error)
-      job.last_error = "{#{error.message}\n#{error.backtrace.join('\n')}"
+      job.last_error = "{#{error.message}\n#{error.backtrace.join("\n")}"
       say "#{job.name} failed with #{error.class.name}: #{error.message} - #{job.attempts} failed attempts", Logger::ERROR
       reschedule(job)
     end


### PR DESCRIPTION
job.last_error has the backtrace joined by the string '\n', rather than a newline character.
