### PR TITLE
Added new callback, :failure_notify to get a callback for every failure if you need it.

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -206,6 +206,7 @@ module Delayed
   protected
 
     def handle_failed_job(job, error)
+      job.hook(:failure_notify)
       job.last_error = "{#{error.message}\n#{error.backtrace.join('\n')}"
       say "#{job.name} failed with #{error.class.name}: #{error.message} - #{job.attempts} failed attempts", Logger::ERROR
       reschedule(job)


### PR DESCRIPTION
Added hook failure_notify to get a callback for every failure, not just the final attempt

I needed a way to send an email alert for each failure, which currently doesnt seem possible, only the final (:failed) hook gets called.  Added a new hook in handle_failed_job called ":failure_notify" that you can do whatever you want with.

 Working nicely for me so far :-)

Cheers,
Adam
