### PR TITLE
Backport connection handling to Rails 2

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -29,9 +29,13 @@ module Delayed
           {:conditions => ['(run_at <= ? AND (locked_at IS NULL OR locked_at < ?) OR locked_by = ?) AND failed_at IS NULL', db_time_now, db_time_now - max_run_time, worker_name]}
         }
         named_scope :by_priority, :order => 'priority ASC, run_at ASC'
-        
+
+        def self.before_fork
+          ::ActiveRecord::Base.clear_all_connections!
+        end
+
         def self.after_fork
-          ::ActiveRecord::Base.connection.reconnect!
+          ::ActiveRecord::Base.establish_connection
         end
 
         # When a worker is exiting, make sure we don't have any locked jobs.


### PR DESCRIPTION
Hello, I've backported connection handling for `ActiveRecord`.

I was getting `Bad file descriptor` if `ActiveRecord::Base.connection` was used in plugins or initializers before `DJ` was started. I've fixed it by clearing `ActiveRecord` connections in `before_fork` hook. Branch v2.1 already contains fix, so I'm backporting this trivial fix it for legacy apps.
