### PR TITLE
raise ArgumentError if attempting to enqueue a performable method on an object that hasn't been persisted yet

### DIFF
--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -393,6 +393,14 @@ shared_examples_for 'a delayed_job backend' do
       story.update_attributes :text => 'goodbye'
       job.reload.payload_object.object.text.should == 'goodbye'
     end
+    
+    it "should raise error ArgumentError the record is not persisted" do
+      story = Story.new(:text => 'hello')
+      lambda {
+        story.delay.tell 
+      }.should raise_error(ArgumentError, "Jobs cannot be created for records before they've been persisted")
+      
+    end
 
     it "should raise deserialization error for destroyed records" do
       story = Story.create(:text => 'hello')

--- a/lib/delayed/performable_method.rb
+++ b/lib/delayed/performable_method.rb
@@ -8,7 +8,11 @@ module Delayed
 
     def initialize(object, method_name, args)
       raise NoMethodError, "undefined method `#{method_name}' for #{object.inspect}" unless object.respond_to?(method_name, true)
-
+      
+      if object.kind_of?(ActiveRecord::Base)
+        raise(ArgumentError, 'Jobs cannot be created for records before they\'ve been persisted') if object.attributes[object.class.primary_key].nil?
+      end
+      
       self.object       = object
       self.args         = args
       self.method_name  = method_name.to_sym

--- a/spec/message_sending_spec.rb
+++ b/spec/message_sending_spec.rb
@@ -14,7 +14,7 @@ describe Delayed::MessageSending do
     end
 
     it "should create a PerformableMethod" do
-      story = Story.new
+      story = Story.create
       lambda {
         job = story.tell!(1)
         job.payload_object.class.should   == Delayed::PerformableMethod

--- a/spec/performable_method_spec.rb
+++ b/spec/performable_method_spec.rb
@@ -42,7 +42,7 @@ describe Delayed::PerformableMethod do
   describe "hooks" do
     %w(enqueue before after success).each do |hook|
       it "should delegate #{hook} hook to object" do
-        story = Story.new
+        story = Story.create
         story.should_receive(hook).with(an_instance_of(Delayed::Job))
         story.delay.tell.invoke_job
       end
@@ -51,14 +51,14 @@ describe Delayed::PerformableMethod do
     %w(before after success).each do |hook|
       it "should delegate #{hook} hook to object when delay_jobs = false" do
         Delayed::Worker.delay_jobs = false
-        story = Story.new
+        story = Story.create
         story.should_receive(hook).with(an_instance_of(Delayed::Job))
         story.delay.tell
       end
     end
     
     it "should delegate error hook to object" do
-      story = Story.new
+      story = Story.create
       story.should_receive(:error).with(an_instance_of(Delayed::Job), an_instance_of(RuntimeError))
       story.should_receive(:tell).and_raise(RuntimeError)
       lambda { story.delay.tell.invoke_job }.should raise_error
@@ -66,7 +66,7 @@ describe Delayed::PerformableMethod do
     
     it "should delegate error hook to object when delay_jobs = false" do
       Delayed::Worker.delay_jobs = false
-      story = Story.new
+      story = Story.create
       story.should_receive(:error).with(an_instance_of(Delayed::Job), an_instance_of(RuntimeError))
       story.should_receive(:tell).and_raise(RuntimeError)
       lambda { story.delay.tell }.should raise_error


### PR DESCRIPTION
Delaying a method invokation on an object that hasn't been persisted yet (and therefore doesn't have a primary key) will currently save but results in deserialization exceptions when later processed.

This is the opposite end of the deserialization problem (#282 and #296), and is noted in #183.  I had to change the callbacks specs to `Story.create` instead of `Story.new`. I couldn't tell if callbacks on unpersisted objects was a specifically desirable behavior or just one that didn't matter for those specific specs.

I didn't add any behavior for similar failures on Mongoid.
