### PR TITLE
Correct notify_hoptoad example in the readme

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -169,7 +169,7 @@ class ParanoidNewsletterJob < NewsletterJob
   end
 
   def error(job, exception)
-    notify_hoptoad(exception)
+    Airbrake.notify(exception)
   end
 
   def failure


### PR DESCRIPTION
I noticed this issue while implementing some callbacks on a custom job:
1. Hoptoad is now called Airbrake
2. The `notify_airbrake` method is only available in controllers, Airbrake.notify should be used elsewhere
