### PR TITLE
Add custom_logger for script/delayed_job

### DIFF
--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -91,7 +91,7 @@ module Delayed
       Dir.chdir(Rails.root)
 
       Delayed::Worker.after_fork
-      Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))
+      Delayed::Worker.logger ||= Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))
 
       worker = Delayed::Worker.new(@options)
       worker.name_prefix = "#{worker_name} "


### PR DESCRIPTION
When script/delayed_job run, assigns custom_logger to `Delayed::Worker.logger`.

I add `cattributes :custom_logger` in `Delayed::Worker`
custom_logger settings is following:

```
# config/initializers/delayed_job_config.rb
Delayed::Worker.custom_logger = Syslogger.new("app_name", Syslog::LOG_PID, Syslog::LOG_LOCAL2)
```
