### PR TITLE
Allow application to access yaml being deserialized

### DIFF
--- a/spec/yaml_ext_spec.rb
+++ b/spec/yaml_ext_spec.rb
@@ -38,4 +38,52 @@ describe "YAML" do
   it "should not throw an uninitialized constant Syck::Syck when using YAML.load with poorly formed yaml" do
     lambda { YAML.load(YAML.dump("foo: *bar"))}.should_not raise_error
   end
+  
+  it 'should preserve and respect original yaml by calling psych init_with after loading ActiveRecord object' do
+    lambda {
+      class Story < ActiveRecord::Base
+        attr_accessor :counter
+        
+        def init_with(coder)
+          super  # Required due to ActiveRecord deficiency
+          
+          coder['attributes']['text'].should.eql? 'value'
+          coder['attributes']['scoped'].should.eql? 't'
+          coder['attributes']['story_id'].should.eql? 1
+          coder['morestuff'].should.eql? 'xyz'
+          
+          @counter = @counter.blank? ? 1 : @counter + 1
+          self
+        end
+      end
+            
+      YAML.parser.class.name.should match(/psych/i)
+      s = Story.create(:text => 'value')
+      
+      y = "--- !ruby/ActiveRecord:Story\nattributes:\n  text: value\n  scoped: true\n  story_id: 1\nmorestuff: xyz"
+      s2 = YAML.load(y)
+      s2.should_not be_nil
+      s2.text.should == 'value'
+      s2.scoped.should.eql? 't'
+      s2.id.should.eql? 1
+      s2.counter.should == 2
+
+    }.should_not raise_error    
+    end
+  
+  it 'should work fine without a psych init_with after loading ActiveRecord object' do
+    lambda {
+          
+      YAML.parser.class.name.should match(/psych/i)
+      s = Story.create(:text => 'value')
+      
+      y = "--- !ruby/ActiveRecord:Story\nattributes:\n  text: value\n  scoped: true\n  story_id: 1"
+      s2 = YAML.load(y)
+      s2.should_not be_nil
+      s2.text.should == 'value'
+      s2.scoped.should.eql? 't'
+      s2.id.should.eql? 1
+
+    }.should_not raise_error    
+    end
 end


### PR DESCRIPTION
This is the 1st of two companion pull requests (the other in delayed_job_active_record), though this modification can stand alone. When delayed_job changed its deserialization approach to deserialize by populating objects from the database, it lost the ability to deserialize yaml containing extra values beyond database attributes (such as transient attributes). This ability had been available in earlier versions of delayed_job, whether intentionally or not.

This pull request implements a modification that respects the yaml being deserialized by passing it to init_with a second time after populating the deserialized object. This second call to init_with permits application code to intercept the raw yaml being deserialized and act on it.

This modification has been tested in this environment:
- Ruby 1.9.2
- Rubygems 1.8.12
- Gem psych 1.2.2 (the modification doesnt work using native Ruby psych 1.0.0)
- Bundler 1.1.rc.3
- Rails 3.0.10 and 3.1.3

This modification was also tested embedded into an app on Heroku:
- Stack cedar
- Ruby 1.9.2
- Gem psych 1.2.2 (native Ruby psych 1.0.0 not available on Heroku)
- Bundler 1.1.rc.5
- Rails 3.0.10
