### PR TITLE
Removes nil guard that causes silent failures

### DIFF
--- a/lib/delayed/message_sending.rb
+++ b/lib/delayed/message_sending.rb
@@ -16,6 +16,8 @@ module Delayed
 
   module MessageSending
     def delay(options = {})
+      raise NoMethodError, "undefined method `delay' for nil:NilCass" if nil?
+
       DelayProxy.new(PerformableMethod, self, options)
     end
     alias __delay__ delay

--- a/spec/message_sending_spec.rb
+++ b/spec/message_sending_spec.rb
@@ -89,7 +89,7 @@ describe Delayed::MessageSending do
       job.run_at.should == run_at
       job.priority.should == 20
     end
-    
+
     it "should not delay the job when delay_jobs is false" do
       Delayed::Worker.delay_jobs = false
       fairy_tail = FairyTail.new
@@ -99,7 +99,7 @@ describe Delayed::MessageSending do
         }.should change(fairy_tail, :happy_ending).from(nil).to(true)
       }.should_not change { Delayed::Job.count }
     end
-    
+
     it "should delay the job when delay_jobs is true" do
       Delayed::Worker.delay_jobs = true
       fairy_tail = FairyTail.new
@@ -108,6 +108,12 @@ describe Delayed::MessageSending do
           fairy_tail.delay.tell
         }.should_not change(fairy_tail, :happy_ending)
       }.should change { Delayed::Job.count }.by(1)
+    end
+
+    it "should raise a NoMethodError when called on nil" do
+      lambda {
+        nil.delay.inspect
+      }.should raise_error(NoMethodError)
     end
   end
 end


### PR DESCRIPTION
The nil guard in PerformableMethod#perform means that no error is raised when attempting to delay a method on nil:

```
@model = Model.some_lookup_method(params) # => nil
@model.delay.process_something
```

In this example, if `@model` is nil, then PerformableMethod happily ignores the error. It seems like this was by design, because you have a spec for this exact scenario:

```
context "with the persisted record cannot be found" do
  before do
    @method.object = nil 
  end 

  it "should be a no-op if object is nil" do
    lambda { @method.perform }.should_not raise_error
  end 
end 
```

What was the rationale for this design decision? In our particular application, we've found this to be detrimental, because we don't receive failure notices when delaying a method on `nil`.

If you'd like to change the behavior to raise an error instead, I've attached a patch that will do that. If not, it's an easy monkey patch for others to apply. Another alternative is that we can make it configurable: `Delayed::Worker.raise_error_on_nil = true`.
