### PR TITLE
"Can't mass-assign protected attributes:" on custom attributes

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -25,6 +25,7 @@ module Delayed
           end
 
           if Delayed::Worker.delay_jobs
+            self.attr_protected if self.to_s == 'Delayed::Backend::ActiveRecord::Job' # loads protected attributes for ActiveRecord instance
             self.new(options).tap do |job|
               Delayed::Worker.lifecycle.run_callbacks(:enqueue, job) do
                 job.hook(:enqueue)


### PR DESCRIPTION
Have added two additional fields to delayed jobs table:

```
def self.up
  add_column :delayed_jobs, :source_id, :integer
  add_column :delayed_jobs, :job_category, :string
end
```

and after updating to 3.2.1 the following call:

```
SomeModel.delay({:job_category => 'category_name', :source_id => id}).populate
```

produces this:

```
ActiveModel::MassAssignmentSecurity::Error:
   Can't mass-assign protected attributes: source_id, job_category
```

---

Added attr_accessible to my delayed job model

```
class DelayedJob < ActiveRecord::Base
  attr_accessible :source_id, :job_category
  ...
end
```

but this did not solve the problem.

After a little bit of debugging found out that adding line

```
self.attr_protected
```

right before lib/delayed/backend/base.rb:28

```
...
if Delayed::Worker.delay_jobs
    self.attr_protected if self.to_s == 'Delayed::Backend::ActiveRecord::Job'
    self.new(options).tap do |job|
       Delayed::Worker.lifecycle.run_callbacks(:enqueue, job) do
         job.hook(:enqueue)
         job.save
       end
    end
 else
...
```

solves my problem.

---

but I'm not sure what would be the best way how to solve this for good and wether this should be done on delajed_jobs or on active_model side.
Any ideas?
