### PR TITLE
added gem 'daemons' as runtime dependency

### DIFF
--- a/delayed_job.gemspec
+++ b/delayed_job.gemspec
@@ -18,6 +18,7 @@ This gem is collectiveidea's fork (http://github.com/collectiveidea/delayed_job)
   s.test_files        = Dir.glob('spec/**/*')
 
   s.add_runtime_dependency      'activesupport',  '~> 3.0'
+  s.add_runtime_dependency      'daemons',        '~> 1.1.8'
 
   s.add_development_dependency  'activerecord',   '~> 3.0'
   s.add_development_dependency  'sqlite3'


### PR DESCRIPTION
 Can't start workers in production:

```
 RAILS_ENV=production script/delayed_job start
  /Users/duksihug/.rvm/gems/ruby-1.9.3-p0@delayed_job_test/gems/delayed_job-3.0.1/lib/delayed/command.rb:4:in `rescue in <top (required)>': You need to add gem 'daemons' to your Gemfile if you wish to use it. (RuntimeError)
  ...
```
