### PR TITLE
One line fix for a missing 'benchmark' require

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -4,6 +4,7 @@ require 'active_support/core_ext/class/attribute_accessors'
 require 'active_support/core_ext/kernel'
 require 'active_support/core_ext/enumerable'
 require 'logger'
+require 'benchmark'
 
 module Delayed
   class Worker


### PR DESCRIPTION
I've stumbled upon this in my delayed_job installation.

/Library/Ruby/Gems/1.8/gems/delayed_job-3.0.1/lib/delayed/worker.rb:116:in `start': uninitialized constant Delayed::Worker::Benchmark (NameError)

Simple fix is to add a require.
