### PR TITLE
added check for bad alias

### DIFF
--- a/lib/delayed/syck_ext.rb
+++ b/lib/delayed/syck_ext.rb
@@ -14,6 +14,7 @@ class Module
   def yaml_tag_read_class(name)
     # Constantize the object so that ActiveSupport can attempt
     # its auto loading magic. Will raise LoadError if not successful.
+    name.gsub!(/^YAML::/, '') if name =~ /BadAlias/
     name.constantize
     name
   end


### PR DESCRIPTION
In rails 3.2, I have run into countless errors with "Unitialized constant Syck::Syck" pertaining to delayed_job's syck_ext file.  This fixes it.
