### PR TITLE
Development mode

### DIFF
--- a/lib/delayed/message_sending.rb
+++ b/lib/delayed/message_sending.rb
@@ -18,7 +18,7 @@ module Delayed
 
     def method_missing(method, *args)
       if development
-        @target.send method.to_sym, args
+        @target.send method.to_sym, *args
       else
         Job.enqueue({:payload_object => @payload_class.new(@target, method.to_sym, args)}.merge(@options))
       end


### PR DESCRIPTION
Very often in development process I don't use delayed_job for some reason. And I'm ready in development mode to wait some time while function in progress, for example sending tickets to zendesk or mail sending. Also it's more useful for debugging.

But in production mode I want to send this tasks to delayed_job.

In this case I should write something like this

```
if Rails.env.production?
  comment.delay.clone_to_zendesk
else
  comment.clone_to_zendesk
end
```

I think it's not good. I suggest to fix it in config (development.rb for example)

```
Delayed::DelayProxy.development = true
```

in this case `comment.delay.clone_to_zendesk` will be executed without delayed_job in development. And will work through delayed_job in production
