### PR TITLE
Bug in job unlock method

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -106,6 +106,8 @@ module Delayed
       def unlock
         self.locked_at    = nil
         self.locked_by    = nil
+        self.locked_at_will_change!
+        self.locked_by_will_change!
       end
 
       def hook(name, *args)


### PR DESCRIPTION
When job fails (in the 1st attempt of 3 in my case) unlock method does not really update locked_at and locked_by attributes.

attr_name_will_change! solves this problem
