### PR TITLE
Parallelize stop and restart to be faster with many workers

### DIFF
--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -75,10 +75,14 @@ module Delayed
         process_name = "delayed_job.#{@options[:identifier]}"
         run_process(process_name, dir)
       else
+        threads = []
         worker_count.times do |worker_index|
-          process_name = worker_count == 1 ? "delayed_job" : "delayed_job.#{worker_index}"
-          run_process(process_name, dir)
+          threads << Thread.start do
+            process_name = worker_count == 1 ? "delayed_job" : "delayed_job.#{worker_index}"
+            run_process(process_name, dir)
+          end
         end
+        threads.each(&:join)
       end
     end
 


### PR DESCRIPTION
Stoping delayed job via deamons gem is taking ages with many workers, because it sends signal sequentially to each process. In my case, I have 15 workers and have to wait 15 \* 20 seconds (timeout duration) to restart all workers.

My solution is to send each signal in their own thread. Thus, restart duration doesn't increase as many as worker count.
