### PR TITLE
Errored jobs retry immediately in batches of two

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -235,7 +235,7 @@ module Delayed
     # If no jobs are left we return nil
     def reserve_and_run_one_job
       job = Delayed::Job.reserve(self)
-      self.class.lifecycle.run_callbacks(:perform, self, job){ result = run(job) } if job
+      self.class.lifecycle.run_callbacks(:perform, self, job){ result = run(job.reload) } if job
     end
   end
 


### PR DESCRIPTION
I created a ticket at https://github.com/collectiveidea/delayed_job/issues/385 which refers to the problem and solution (incorrectly resolved) at https://github.com/collectiveidea/delayed_job/issues/63.

The problem, in a nutshell, is that attempts 1 and 2 happen immediately following one another, then 3 and 4, then 5 and 6, etc., rather than being correctly spaced out. The reason is because the job record is not reloaded from the database and therefore has an inconsistent lock time. The solution is to reload the job before trying to run it.
