### PR TITLE
Add group.  Add note about /bin/su

### DIFF
--- a/contrib/delayed_job_multiple.monitrc
+++ b/contrib/delayed_job_multiple.monitrc
@@ -3,21 +3,32 @@
 # To use:
 # 1. copy to /var/www/apps/{app_name}/shared/delayed_job.monitrc
 # 2. replace {app_name} as appropriate
+#    you might also need to change the program strings to
+#           "/bin/su - {username} -c '/usr/bin/env ...'" 
+#    to load your shell environment.
+#
 # 3. add this to your /etc/monit/monitrc
 #
 #   include /var/www/apps/{app_name}/shared/delayed_job.monitrc
+#
+# The processes are grouped so that monit can act on them as a whole, e.g.
+#
+#   monit -g delayed_job restart
 
 check process delayed_job_0
   with pidfile /var/www/apps/{app_name}/shared/pids/delayed_job.0.pid
   start program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/script/delayed_job start -i 0"
   stop program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/script/delayed_job stop -i 0"
+  group delayed_job
 
 check process delayed_job_1
   with pidfile /var/www/apps/{app_name}/shared/pids/delayed_job.1.pid
   start program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/script/delayed_job start -i 1"
   stop program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/script/delayed_job stop -i 1"
+  group delayed_job
 
 check process delayed_job_2
   with pidfile /var/www/apps/{app_name}/shared/pids/delayed_job.2.pid
   start program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/script/delayed_job start -i 2"
   stop program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/script/delayed_job stop -i 2"
+  group delayed_job


### PR DESCRIPTION
Some suggested changes from my own experience.   

'group' seems to be a new feature of monit, so not everyone might be aware of it.  

and the note about /bin/su could save people time trying to track down why monit fails (without any explanation) when it tries to run the start or stop program.
