### PR TITLE
more useful log message for delayed mailer

### DIFF
--- a/lib/delayed/performable_mailer.rb
+++ b/lib/delayed/performable_mailer.rb
@@ -5,6 +5,10 @@ module Delayed
     def perform
       object.send(method_name, *args).deliver
     end
+
+    def display_name
+      "#{object}.#{method_name}"
+    end
   end
 
   module DelayMail


### PR DESCRIPTION
current 'Class#notice' isn't really helpful.
that commit changes display_name to something like 'FooMailer.notice'
