### PR TITLE
Remove unnecessary curly brace from last_error.

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -188,7 +188,7 @@ module Delayed
       say "#{job.name} completed after %.4f" % runtime
       return true  # did work
     rescue DeserializationError => error
-      job.last_error = "{#{error.message}\n#{error.backtrace.join("\n")}"
+      job.last_error = "#{error.message}\n#{error.backtrace.join("\n")}"
       failed(job)
     rescue Exception => error
       self.class.lifecycle.run_callbacks(:error, self, job){ handle_failed_job(job, error) }
@@ -229,7 +229,7 @@ module Delayed
   protected
 
     def handle_failed_job(job, error)
-      job.last_error = "{#{error.message}\n#{error.backtrace.join("\n")}"
+      job.last_error = "#{error.message}\n#{error.backtrace.join("\n")}"
       say "#{job.name} failed with #{error.class.name}: #{error.message} - #{job.attempts} failed attempts", Logger::ERROR
       reschedule(job)
     end


### PR DESCRIPTION
First introduced in collectiveidea/delayed_job@2b23b80, which added a "{" at the beginning.
