### PR TITLE
Fix deserialization error crash

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -83,7 +83,7 @@ module Delayed
 
       def payload_object
         @payload_object ||= YAML.load(self.handler)
-      rescue TypeError, LoadError, NameError, ArgumentError => e
+      rescue Exception => e
         raise DeserializationError,
           "Job failed to load: #{e.message}. Handler: #{handler.inspect}"
       end

--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -174,6 +174,12 @@ shared_examples_for 'a delayed_job backend' do
       YAML.should_receive(:load).and_raise(ArgumentError)
       lambda { job.payload_object }.should raise_error(Delayed::DeserializationError)
     end
+
+    it "should raise a DeserializationError when the YAML.load raises an unexpected error" do
+      job = described_class.new :handler => "--- !ruby/struct:GoingToRaiseArgError {}"
+      YAML.should_receive(:load).and_raise(Exception)
+      lambda { job.payload_object }.should raise_error(Delayed::DeserializationError)
+    end
   end
 
   describe "reserve" do


### PR DESCRIPTION
DJ was crashing when unexpected exception has been raised from
YAML.load. Changed it to rescue all Exceptions and transform them to
DeserializationErrors.
