### PR TITLE
fixes https://github.com/collectiveidea/delayed_job/issues/212 

### DIFF
--- a/lib/delayed/recipes.rb
+++ b/lib/delayed/recipes.rb
@@ -34,7 +34,7 @@ Capistrano::Configuration.instance.load do
 
     desc "Stop the delayed_job process"
     task :stop, :roles => lambda { roles } do
-      run "cd #{current_path};#{rails_env} script/delayed_job stop"
+      run "cd #{current_path};#{rails_env} script/delayed_job stop #{args}"
     end
 
     desc "Start the delayed_job process"


### PR DESCRIPTION
pass the arguments to the stop command in the capistrano task, so the pid directory and workers number can be correctly used
