### PR TITLE
Quickstart section for README

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -57,7 +57,7 @@ h2. Quick Start
 Once you have Delayed Job installed and have done the database migration, there are three basic ways to schedule a job to be processed in the background:
 
 <pre>
-# Way #1: call @.delay.method(params)@ on any object
+# Way #1: call .delay.method(params) on any object
 
 @user.delay.activate!(@device) 
 


### PR DESCRIPTION
I ran into someone who was confused by the docs and thought that they had to create a custom job type for any kind of job they wanted to run. I realized that there are no fewer than three ways to get a job in the DB and there was no side-by-side comparison of them. Hence, this doc patch, humbly submitted.

--Phil
