### PR TITLE
Fix Delayed::PerformableMethod#display_name to handle class methods

### DIFF
--- a/lib/delayed/performable_method.rb
+++ b/lib/delayed/performable_method.rb
@@ -19,7 +19,11 @@ module Delayed
     end
 
     def display_name
-      "#{object.class}##{method_name}"
+      if object.is_a?(Class)
+        "#{object}.#{method_name}"
+      else
+        "#{object.class}##{method_name}"
+      end
     end
 
     def perform

--- a/spec/performable_method_spec.rb
+++ b/spec/performable_method_spec.rb
@@ -39,6 +39,21 @@ describe Delayed::PerformableMethod do
     }.not_to raise_error(NoMethodError)
   end
 
+  describe "display_name" do
+    it "returns class_name#method_name for instance methods" do
+      expect(Delayed::PerformableMethod.new("foo", :count, ['o']).display_name).to eq('String#count')
+    end
+
+    it "returns class_name.method_name for class methods" do
+      SomeClass = Class.new do
+        def self.class_method
+        end
+      end
+
+      expect(Delayed::PerformableMethod.new(SomeClass, :class_method, []).display_name).to eq('SomeClass.class_method')
+    end
+  end
+
   describe "hooks" do
     %w(enqueue before after success).each do |hook|
       it "delegates #{hook} hook to object" do


### PR DESCRIPTION
`Delayed::PerformableMethod#display_name` was previously returning something like `Class#class_method_name` for a class method named `class_method_name`. This PR fixes it so it correctly returns `SomeClass.class_method_name`.

Specs included.
