### PR TITLE
Require rspec ~> 2.11

### DIFF
--- a/delayed_job.gemspec
+++ b/delayed_job.gemspec
@@ -21,7 +21,7 @@ This gem is collectiveidea's fork (http://github.com/collectiveidea/delayed_job)
 
   s.add_development_dependency  'activerecord',   '~> 3.0'
   s.add_development_dependency  'actionmailer',   '~> 3.0'
-  s.add_development_dependency  'rspec',          '~> 2.0'
+  s.add_development_dependency  'rspec',          '~> 2.11'
   s.add_development_dependency  'rake'
   s.add_development_dependency  'simplecov'
 end


### PR DESCRIPTION
Specs fail when using rspec 2.10.0 with 60+ errors similar to:

```
Failure/Error: expect(job).to be_failed
 ArgumentError:
   wrong number of arguments (1 for 0)
```
