### PR TITLE
Allow queue name of NULL to mean "this worker can do jobs with no queue specified"

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -170,6 +170,11 @@ QUEUE=tracking rake jobs:work
 QUEUES=mailers,tasks rake jobs:work
 </pre>
 
+Specify a queue name of NULL to allow a worker to do jobs that have no queue specified:
+<pre>
+QUEUES=mailers,NULL rake jobs:work
+</pre>
+
 h2. Custom Jobs
 
 Jobs are simple ruby objects with a method called perform. Any object which responds to perform can be stuffed into the jobs table. Job objects are serialized to yaml so that they can later be resurrected by the job runner.

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -53,6 +53,10 @@ module Delayed
       RAILS_DEFAULT_LOGGER
     end
 
+    def self.queues=(queues)
+      @@queues = queues.map{|q| q == 'NULL' ? nil : q }
+    end
+
     def self.backend=(backend)
       if backend.is_a? Symbol
         require "delayed/serialization/#{backend}"

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -21,6 +21,15 @@ describe Delayed::Worker do
     end
   end
 
+  describe "queues=" do
+    before do
+      Delayed::Worker.queues = %w(mailers NULL)
+    end
+    it 'sets the array to include nil' do
+      expect(Delayed::Worker.queues).to eq(['mailers', nil])
+    end
+  end
+
   context "worker read-ahead" do
     before do
       @read_ahead = Delayed::Worker.read_ahead


### PR DESCRIPTION
fixes #425
