### PR TITLE
Add rake jobs:work_once. A one-off task that runs everything in the queue and exits.

### DIFF
--- a/lib/delayed/tasks.rb
+++ b/lib/delayed/tasks.rb
@@ -8,4 +8,13 @@ namespace :jobs do
   task :work => :environment do
     Delayed::Worker.new(:min_priority => ENV['MIN_PRIORITY'], :max_priority => ENV['MAX_PRIORITY'], :queues => (ENV['QUEUES'] || ENV['QUEUE'] || '').split(','), :quiet => false).start
   end
+
+  desc "Works all jobs in the queue (if any) and exits."
+  task :work_once => :environment do
+    job_count = Delayed::Job.count
+    puts "There are #{job_count} jobs in the queue."
+    result = Delayed::Job.work_off job_count
+    puts "#{result.sum} jobs processed: #{result.first} succeeded, #{result.last} failed." 
+  end
+
 end


### PR DESCRIPTION
I've found this to be useful for using Delayed Job in situations where I don't need a worker constantly running, or the tasks aren't pressing, or I want to save money on Heroku by running jobs with the [Heroku Scheduler](https://addons.heroku.com/scheduler) rather than on a separate worker dyno.
