### PR TITLE
Use AR#attributes instead of the instance variable

### DIFF
--- a/lib/delayed/psych_ext.rb
+++ b/lib/delayed/psych_ext.rb
@@ -2,8 +2,8 @@ if defined?(ActiveRecord)
   class ActiveRecord::Base
     # serialize to YAML
     def encode_with(coder)
-      coder["attributes"] = @attributes
-      coder.tag = ['!ruby/ActiveRecord', self.class.name].join(':')
+      super
+      coder.tag = "!ruby/ActiveRecord:#{self.class.name}"
     end
   end
 end


### PR DESCRIPTION
As of Rails 3.2.12, they can return different things.
For example, if the `foorbars` table has an integer column called "size" with default 0 and not null:

```
f = Foobar.new
f.attributes["size"].class #=> Fixnum
f.instance_eval{@attributes}["size"].class #=> Arel::Nodes::SqlLiteral
```

This fixes an issue where:

```
Foobar.new.to_yaml
```

would raise an error:

```
ArgumentError: wrong number of arguments (2 for 1)
    from gems/arel-3.0.2/lib/arel/expressions.rb:3:in `count'
```
