### PR TITLE
updated coverage badge image / url

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Delayed::Job
 [![Build Status](https://secure.travis-ci.org/collectiveidea/delayed_job.png?branch=master)][travis]
 [![Dependency Status](https://gemnasium.com/collectiveidea/delayed_job.png?travis)][gemnasium]
 [![Code Climate](https://codeclimate.com/github/collectiveidea/delayed_job.png)][codeclimate]
-[![Coverage Status](https://coveralls.io/repos/lemurheavy/delayed_job/badge.png?branch=master)][coveralls]
+[![Coverage Status](https://coveralls.io/repos/collectiveidea/delayed_job/badge.png?branch=master)][coveralls]
 
 [gem]: https://rubygems.org/gems/delayed_job
 [travis]: http://travis-ci.org/collectiveidea/delayed_job
 [gemnasium]: https://gemnasium.com/collectiveidea/delayed_job
 [codeclimate]: https://codeclimate.com/github/collectiveidea/delayed_job
-[coveralls]: https://coveralls.io/r/lemurheavy/delayed_job
+[coveralls]: https://coveralls.io/r/collectiveidea/delayed_job
 
 Delayed::Job (or DJ) encapsulates the common pattern of asynchronously executing
 longer tasks in the background.


### PR DESCRIPTION
Uses https://coveralls.io/r/collectiveidea/delayed_job instead of the https://coveralls.io/r/lemurheavy/delayed_job fork.
