### PR TITLE
Replace script/delayed_job with bin/delayed_job for Rails 4 compatbility

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ handle_asynchronously :tweet_later, :queue => 'tweets'
 
 Running Jobs
 ============
-`script/delayed_job` can be used to manage a background process which will
+`bin/delayed_job` can be used to manage a background process which will
 start working off jobs.
 
 To do so, add `gem "daemons"` to your `Gemfile` and make sure you've run `rails
@@ -164,21 +164,21 @@ generate delayed_job`.
 
 You can then do the following:
 
-    RAILS_ENV=production script/delayed_job start
-    RAILS_ENV=production script/delayed_job stop
+    RAILS_ENV=production bin/delayed_job start
+    RAILS_ENV=production bin/delayed_job stop
 
     # Runs two workers in separate processes.
-    RAILS_ENV=production script/delayed_job -n 2 start
-    RAILS_ENV=production script/delayed_job stop
+    RAILS_ENV=production bin/delayed_job -n 2 start
+    RAILS_ENV=production bin/delayed_job stop
 
     # Set the --queue or --queues option to work from a particular queue.
-    RAILS_ENV=production script/delayed_job --queue=tracking start
-    RAILS_ENV=production script/delayed_job --queues=mailers,tasks start
+    RAILS_ENV=production bin/delayed_job --queue=tracking start
+    RAILS_ENV=production bin/delayed_job --queues=mailers,tasks start
 
     # Runs all available jobs and the exits
-    RAILS_ENV=production script/delayed_job start --exit-on-complete
+    RAILS_ENV=production bin/delayed_job start --exit-on-complete
     # or to run in the foreground
-    RAILS_ENV=production script/delayed_job run --exit-on-complete
+    RAILS_ENV=production bin/delayed_job run --exit-on-complete
 
 Workers can be running on any computer, as long as they have access to the
 database and their clock is in sync. Keep in mind that each worker will check

--- a/contrib/delayed_job.monitrc
+++ b/contrib/delayed_job.monitrc
@@ -10,5 +10,5 @@
 
 check process delayed_job
   with pidfile /var/www/apps/{app_name}/shared/pids/delayed_job.pid
-  start program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/script/delayed_job start"
-  stop program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/script/delayed_job stop"
+  start program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/bin/delayed_job start"
+  stop program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/bin/delayed_job stop"

--- a/contrib/delayed_job_multiple.monitrc
+++ b/contrib/delayed_job_multiple.monitrc
@@ -17,18 +17,18 @@
 
 check process delayed_job_0
   with pidfile /var/www/apps/{app_name}/shared/pids/delayed_job.0.pid
-  start program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/script/delayed_job start -i 0"
-  stop program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/script/delayed_job stop -i 0"
+  start program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/bin/delayed_job start -i 0"
+  stop program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/bin/delayed_job stop -i 0"
   group delayed_job
 
 check process delayed_job_1
   with pidfile /var/www/apps/{app_name}/shared/pids/delayed_job.1.pid
-  start program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/script/delayed_job start -i 1"
-  stop program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/script/delayed_job stop -i 1"
+  start program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/bin/delayed_job start -i 1"
+  stop program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/bin/delayed_job stop -i 1"
   group delayed_job
 
 check process delayed_job_2
   with pidfile /var/www/apps/{app_name}/shared/pids/delayed_job.2.pid
-  start program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/script/delayed_job start -i 2"
-  stop program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/script/delayed_job stop -i 2"
+  start program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/bin/delayed_job start -i 2"
+  stop program = "/usr/bin/env RAILS_ENV=production /var/www/apps/{app_name}/current/bin/delayed_job stop -i 2"
   group delayed_job

--- a/lib/delayed/compatibility.rb
+++ b/lib/delayed/compatibility.rb
@@ -1,0 +1,25 @@
+require 'active_support/version'
+
+module Delayed
+  module Compatibility
+    if ActiveSupport::VERSION::MAJOR >= 4
+      def self.executable_prefix
+        'bin'
+      end
+
+      def self.proxy_object_class
+        require 'active_support/proxy_object'
+        ActiveSupport::ProxyObject
+      end
+    else
+      def self.executable_prefix
+        'script'
+      end
+
+      def self.proxy_object_class
+        require 'active_support/basic_object'
+        ActiveSupport::BasicObject
+      end
+    end
+  end
+end

--- a/lib/delayed/message_sending.rb
+++ b/lib/delayed/message_sending.rb
@@ -1,19 +1,7 @@
-if ActiveSupport::VERSION::MAJOR == 4
-  require 'active_support/proxy_object'
-else
-  require 'active_support/basic_object'
-end
-
 require 'active_support/core_ext/module/aliasing'
 
 module Delayed
-  if ActiveSupport::VERSION::MAJOR == 4
-    klass = ActiveSupport::ProxyObject
-  else
-    klass = ActiveSupport::BasicObject
-  end
-
-  class DelayProxy < klass
+  class DelayProxy < Delayed::Compatibility.proxy_object_class
     def initialize(payload_class, target, options)
       @payload_class = payload_class
       @target = target

--- a/lib/delayed/recipes.rb
+++ b/lib/delayed/recipes.rb
@@ -33,7 +33,7 @@ Capistrano::Configuration.instance.load do
     end
 
     def delayed_job_command
-      fetch(:delayed_job_command, "script/delayed_job")
+      fetch(:delayed_job_command, "bin/delayed_job")
     end
 
     desc "Stop the delayed_job process"

--- a/lib/delayed_job.rb
+++ b/lib/delayed_job.rb
@@ -1,4 +1,5 @@
 require 'active_support'
+require 'delayed/compatibility'
 require 'delayed/exceptions'
 require 'delayed/message_sending'
 require 'delayed/performable_method'

--- a/lib/generators/delayed_job/delayed_job_generator.rb
+++ b/lib/generators/delayed_job/delayed_job_generator.rb
@@ -1,11 +1,12 @@
 require 'rails/generators'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'delayed', 'compatibility'))
 
 class DelayedJobGenerator < Rails::Generators::Base
 
   self.source_paths << File.join(File.dirname(__FILE__), 'templates')
 
-  def create_script_file
-    template 'script', 'script/delayed_job'
-    chmod 'script/delayed_job', 0755
+  def create_executable_file
+    template Delayed::Compatibility.executable_prefix, "#{Delayed::Compatibility.executable_prefix}/delayed_job"
+    chmod "#{Delayed::Compatibility.executable_prefix}/delayed_job", 0755
   end
 end

--- a/lib/generators/delayed_job/templates/bin
+++ b/lib/generators/delayed_job/templates/bin
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+require_relative '../config/boot'
+require_relative '../config/environment'
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/lib/generators/delayed_job/templates/script
+++ b/lib/generators/delayed_job/templates/script
@@ -1,5 +1,0 @@
-#!/usr/bin/env ruby
-
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
-require 'delayed/command'
-Delayed::Command.new(ARGV).daemonize


### PR DESCRIPTION
I started a new Rails 4 app and realised the generator was creating RAILS_ROOT/script/delayed_job. This directory has been replaced in Rails 4 with RAILS_ROOT/bin and binstubs. I'm using this binstub in production.

I noticed there are no tests for the generators. I've tested it locally with a brand new Rails 4 app.

I'm also happy to write a new rake task for upgrading from DJ 3 to DJ 4.
