### PR TITLE
Documented _without_delay feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ class LongTasks
 end
 ```
 
+If you ever want to call a `handle_asynchronously`'d method without Delayed Job, for instance while debugging something at the console, just add `_without_delay` to the method name. For instance, if your original method was `foo`, then call `foo_without_delay`.
+
 Rails 3 Mailers
 ===============
 Due to how mailers are implemented in Rails 3, we had to do a little work around to get delayed_job to work.


### PR DESCRIPTION
I learned about this feature by asking a Stack Overflow question, and thought it deserved to be documented:

http://stackoverflow.com/questions/15443204/call-a-handle-asynchronously-method-synchronously/15557245

My ulterior motive is that if I document it, it will be official and less likely to disappear. :-)
