### PR TITLE
Add jobs:check rake task to test for liveness.

### DIFF
--- a/lib/delayed/tasks.rb
+++ b/lib/delayed/tasks.rb
@@ -22,4 +22,17 @@ namespace :jobs do
       :quiet => false
     }
   end
+
+  desc "Exit with error status if any jobs older than max_age seconds haven't been attempted yet."
+  task :check, [:max_age] => :environment do |_, args|
+    args.with_defaults(:max_age => 300)
+
+    unprocessed_jobs = Delayed::Job.where('attempts = 0 AND created_at < ?', Time.now - args[:max_age].to_i).count
+
+    if unprocessed_jobs > 0
+      fail "#{unprocessed_jobs} jobs older than #{args[:max_age]} seconds have not been processed yet"
+    end
+
+  end
+
 end


### PR DESCRIPTION
This task exits with failure status if there are old jobs that have
not been picked up by workers. This can be used for monitoring.
