### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,19 @@ end
 
 Delayed::Job.enqueue NewsletterJob.new('lorem ipsum...', Customers.find(:all).collect(&:email))
 ```
+To set a per-job max attempts that overrides the Delayed::Worker.max_attempts you can define a max_attempts method on the job
+```ruby
+class NewsletterJob < Struct.new(:text, :emails)
+  def perform
+    emails.each { |e| NewsletterMailer.deliver_text_to_email(text, e) }
+  end
+  
+  def max_attempts
+    return 3
+  end
+end
+````
+
 
 Hooks
 =====


### PR DESCRIPTION
Documents the changes that were made in the pull request:
https://github.com/collectiveidea/delayed_job/pull/168/files

Looking at the code in that PR I figured that the max_attempts needs to be set on the payload/job object on which perform also exists and I tried setting it on the custom job and it worked as expected. This feature is indeed very useful and hopefully this is well-documented and maintained in future releases. Greatly appreciate this gem!

A question - would this work with passing :max_attempts in the options? Didn't seem like it would in the code. Also, the DB table does not have the max_attempts as a column so didn't seem like passing it in options would work. 

Seemed like it only worked with the Delayed::Job.enqueue job usage with max_attempts on job set. Also, it looked like it could work on object.delay.some_method usage with the object having max_attempts on it set (since the DelayProxy is instantiated with the object as the payload_class). However, I only tried the first usage, not the second so, let me know if I am wrong. Would be glad to try out the second usage too in case it is needed.
