### PR TITLE
Update some rspec methods that warn of deprecations.

### DIFF
--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -399,7 +399,7 @@ shared_examples_for "a delayed_job backend" do
     end
 
     it "uses the max_retries value on the payload when defined" do
-      @job.payload_object.stub!(:max_attempts).and_return(99)
+      @job.payload_object.stub(:max_attempts).and_return(99)
       expect(@job.max_attempts).to eq(99)
     end
   end
@@ -504,8 +504,8 @@ shared_examples_for "a delayed_job backend" do
 
       it "does not fail when the triggered error doesn't have a message" do
         error_with_nil_message = StandardError.new
-        error_with_nil_message.stub!(:message).and_return nil
-        @job.stub!(:invoke_job).and_raise error_with_nil_message
+        error_with_nil_message.stub(:message).and_return nil
+        @job.stub(:invoke_job).and_raise error_with_nil_message
         expect{worker.run(@job)}.not_to raise_error
       end
     end
@@ -548,7 +548,7 @@ shared_examples_for "a delayed_job backend" do
           it "does not try to run that hook" do
             expect {
               Delayed::Worker.max_attempts.times { worker.reschedule(@job) }
-            }.not_to raise_exception(NoMethodError)
+            }.not_to raise_exception
           end
         end
       end

--- a/spec/lifecycle_spec.rb
+++ b/spec/lifecycle_spec.rb
@@ -4,7 +4,7 @@ describe Delayed::Lifecycle do
   let(:lifecycle) { Delayed::Lifecycle.new }
   let(:callback) { lambda {|*args|} }
   let(:arguments) { [1] }
-  let(:behavior) { mock(Object, :before! => nil, :after! => nil, :inside! => nil) }
+  let(:behavior) { double(Object, :before! => nil, :after! => nil, :inside! => nil) }
   let(:wrapped_block) { Proc.new { behavior.inside! } }
 
   describe "before callbacks" do

--- a/spec/performable_mailer_spec.rb
+++ b/spec/performable_mailer_spec.rb
@@ -30,8 +30,8 @@ describe ActionMailer::Base do
   describe Delayed::PerformableMailer do
     describe "perform" do
       it "calls the method and #deliver on the mailer" do
-        email = mock('email', :deliver => true)
-        mailer_class = mock('MailerClass', :signup => email)
+        email = double('email', :deliver => true)
+        mailer_class = double('MailerClass', :signup => email)
         mailer = Delayed::PerformableMailer.new(mailer_class, :signup, ['john@example.com'])
 
         mailer_class.should_receive(:signup).with('john@example.com')

--- a/spec/performable_method_spec.rb
+++ b/spec/performable_method_spec.rb
@@ -36,7 +36,7 @@ describe Delayed::PerformableMethod do
     end
     expect {
       Delayed::PerformableMethod.new(clazz.new, :private_method, [])
-    }.not_to raise_error(NoMethodError)
+    }.not_to raise_error
   end
 
   describe "hooks" do

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -24,7 +24,7 @@ describe Delayed::Worker do
   describe "job_say" do
     before do
       @worker = Delayed::Worker.new
-      @job = stub('job', :id => 123, :name => 'ExampleJob')
+      @job = double('job', :id => 123, :name => 'ExampleJob')
     end
 
     it "logs with job name and id" do


### PR DESCRIPTION
When I ran the specs I got a few deprecation notices: `stub!` (an alias for `stub`) is being removed, `mock` is being removed in favor of existing `double`, and `raise_error()`/`raise_exception()` will not take specific errors when used in negative expectations.
