### PR TITLE
Point to Rails 4 in travis settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,20 +15,20 @@ env:
     - "RAILS_VERSION=\"~> 3.0.0\""
     - "RAILS_VERSION=\"~> 3.1.0\""
     - "RAILS_VERSION=\"~> 3.2.0\""
-    - "RAILS_VERSION=\"~> 4.0.0.beta\""
+    - "RAILS_VERSION=\"~> 4.0.0\""
 matrix:
   exclude:
     - rvm: jruby-18mode
-      env: "RAILS_VERSION=\"~> 4.0.0.beta\""
+      env: "RAILS_VERSION=\"~> 4.0.0\""
     - rvm: rbx-18mode
-      env: "RAILS_VERSION=\"~> 4.0.0.beta\""
+      env: "RAILS_VERSION=\"~> 4.0.0\""
     - rvm: 1.8.7
-      env: "RAILS_VERSION=\"~> 4.0.0.beta\""
+      env: "RAILS_VERSION=\"~> 4.0.0\""
     - rvm: 1.9.2
-      env: "RAILS_VERSION=\"~> 4.0.0.beta\""
+      env: "RAILS_VERSION=\"~> 4.0.0\""
   allow_failures:
     - rvm: jruby-18mode
     - rvm: jruby-19mode
     - rvm: rbx-18mode
     - rvm: rbx-19mode
-    - env: "RAILS_VERSION=\"~> 4.0.0.beta\""
+    - env: "RAILS_VERSION=\"~> 4.0.0\""


### PR DESCRIPTION
Getting ready for official `4.0.0` by point to the the Rails release.
