### PR TITLE
Use the appropiate executable folder on the capistrano recipe

### DIFF
--- a/lib/delayed/recipes.rb
+++ b/lib/delayed/recipes.rb
@@ -33,7 +33,7 @@ Capistrano::Configuration.instance.load do
     end
 
     def delayed_job_command
-      fetch(:delayed_job_command, "script/delayed_job")
+      fetch(:delayed_job_command, "#{Delayed::Compatibility.executable_prefix}/delayed_job")
     end
 
     desc "Stop the delayed_job process"


### PR DESCRIPTION
Use the appropiate executable folder on the capistrano recipe  according to the ActiveSupport::VERSION
