### PR TITLE
Fix using Struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Custom Jobs
 Jobs are simple ruby objects with a method called perform. Any object which responds to perform can be stuffed into the jobs table. Job objects are serialized to yaml so that they can later be resurrected by the job runner.
 
 ```ruby
-class NewsletterJob < Struct.new(:text, :emails)
+NewsletterJob = Struct.new(:text, :emails) do
   def perform
     emails.each { |e| NewsletterMailer.deliver_text_to_email(text, e) }
   end
@@ -234,7 +234,7 @@ Delayed::Job.enqueue NewsletterJob.new('lorem ipsum...', Customers.find(:all).co
 ```
 To set a per-job max attempts that overrides the Delayed::Worker.max_attempts you can define a max_attempts method on the job
 ```ruby
-class NewsletterJob < Struct.new(:text, :emails)
+NewsletterJob = Struct.new(:text, :emails) do
   def perform
     emails.each { |e| NewsletterMailer.deliver_text_to_email(text, e) }
   end


### PR DESCRIPTION
`Struct.new` returns a class. Inheritance isn't required.

```
class NewsletterJob < Struct.new(:text, :emails)
  def perform
  end
end

NewsletterJob.superclass # => #<Class:0x007ffa829adad8>
NewsletterJob.superclass.superclass # => Struct

Test = Struct.new(:foo) do
  def perform
  end
end
Test.superclass # => Struct
```
