### PR TITLE
Add :on_no_matching_servers to capistrano tasks.

### DIFF
--- a/lib/delayed/recipes.rb
+++ b/lib/delayed/recipes.rb
@@ -37,17 +37,17 @@ Capistrano::Configuration.instance.load do
     end
 
     desc "Stop the delayed_job process"
-    task :stop, :roles => lambda { roles } do
+    task :stop, :roles => lambda { roles }, :on_no_matching_servers => :continue do
       run "cd #{current_path};#{rails_env} #{delayed_job_command} stop"
     end
 
     desc "Start the delayed_job process"
-    task :start, :roles => lambda { roles } do
+    task :start, :roles => lambda { roles }, :on_no_matching_servers => :continue do
       run "cd #{current_path};#{rails_env} #{delayed_job_command} start #{args}"
     end
 
     desc "Restart the delayed_job process"
-    task :restart, :roles => lambda { roles } do
+    task :restart, :roles => lambda { roles }, :on_no_matching_servers => :continue do
       run "cd #{current_path};#{rails_env} #{delayed_job_command} restart #{args}"
     end
   end


### PR DESCRIPTION
If Capistrano does not find a matching server for a delayed_job task it stops execution, but sometimes you change your deploy script and there are no matching servers for a delayed_job task but you still want to keep the task there. 

It is possible to tell Capistrano to continue adding the option `:on_no_matching_servers => :continue` and the task will be just skipped `** skipping 'delayed_job:restart' because no servers matched`.
