### PR TITLE
Added Delayed::Job.current_rate and rake task jobs:current_rate

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -63,6 +63,20 @@ module Delayed
           warn "[DEPRECATION] `Delayed::Job.work_off` is deprecated. Use `Delayed::Worker.new.work_off instead."
           Delayed::Worker.new.work_off(num)
         end
+
+        def current_rate(seconds = 5)
+          start_time  = Time.now
+          start_count = Delayed::Job.count
+
+          sleep seconds
+
+          end_time    =  Time.now
+          end_count   = Delayed::Job.count
+
+          time  = end_time - start_time
+          count = start_count - end_count
+          return (count/time).to_f
+        end
       end
 
       def failed?

--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -39,6 +39,15 @@ shared_examples_for "a delayed_job backend" do
     end
   end
 
+  describe "current_rate" do
+    it "returns the current rate" do
+      Time.stub(:now).and_return(0,5)
+      described_class.stub(:count).and_return(5,0)
+      described_class.stub(:sleep)
+      expect(described_class.current_rate).to eql 1.0
+    end
+  end
+
   describe "enqueue" do
     context "with a hash" do
       it "raises ArgumentError when handler doesn't respond_to :perform" do

--- a/lib/delayed/tasks.rb
+++ b/lib/delayed/tasks.rb
@@ -14,6 +14,11 @@ namespace :jobs do
     Delayed::Worker.new(@worker_options.merge({:exit_on_complete => true})).start
   end
 
+  desc "Print the current rate of jobs per second"
+  task :current_rate => :environment do
+    puts "Current work-off rate is #{Delayed::Job.current_rate} jobs per second"
+  end
+
   task :environment_options => :environment do
     @worker_options = {
       :min_priority => ENV['MIN_PRIORITY'],


### PR DESCRIPTION
```
rake jobs:current_rate

# =>  Current work-off rate is 10.123 jobs per second
```

I used this to measure the work-off rate ad-hoc when changing sth. like the number of workers. Maybe this is helpfull for others too. 
