### PR TITLE
Bugfix for encode_with_override psych extension

### DIFF
--- a/lib/delayed/psych_ext.rb
+++ b/lib/delayed/psych_ext.rb
@@ -3,14 +3,14 @@ if defined?(ActiveRecord)
     if instance_methods.include?(:encode_with)
       def encode_with_override(coder)
         encode_with_without_override(coder)
-        coder.tag = "!ruby/ActiveRecord:#{self.class.name}"
+        coder.tag = "!ruby/ActiveRecord:#{self.class.name}" if coder.respond_to?(:tag=)
       end
       alias_method :encode_with_without_override, :encode_with
       alias_method :encode_with, :encode_with_override
     else
       def encode_with(coder)
         coder["attributes"] = attributes
-        coder.tag = "!ruby/ActiveRecord:#{self.class.name}"
+        coder.tag = "!ruby/ActiveRecord:#{self.class.name}" if coder.respond_to?(:tag=)
       end
     end
   end


### PR DESCRIPTION
The `coder` passed to`ActiveRecord::Base#encode_with` does not necessarily have
a `tag=` method (it may just be a `Hash`). This causes issues with other callers,
eg https://github.com/Shopify/identity_cache/blob/master/lib/identity_cache/query_api.rb#L140

Fixes https://github.com/collectiveidea/delayed_job/issues/435
