### PR TITLE
Fix YAML deserialization of anonymous structs

### DIFF
--- a/lib/delayed/psych_ext.rb
+++ b/lib/delayed/psych_ext.rb
@@ -136,6 +136,7 @@ module Psych
       alias_method_chain :visit_Psych_Nodes_Mapping, :class
 
       def resolve_class_with_constantize(klass_name)
+        return nil if !klass_name || klass_name.empty?
         klass_name.constantize
       rescue
         resolve_class_without_constantize(klass_name)

--- a/spec/yaml_ext_spec.rb
+++ b/spec/yaml_ext_spec.rb
@@ -22,6 +22,15 @@ describe 'YAML' do
     end.not_to raise_error
   end
 
+  it 'autoloads the class of an anonymous struct' do
+    expect do
+      yaml = "--- !ruby/struct\nn: 1\n"
+      object = YAML.load(yaml)
+      expect(object).to be_kind_of(Struct)
+      expect(object.n).to eq(1)
+    end.not_to raise_error
+  end
+
   it 'autoloads the class for the instance' do
     expect do
       yaml = "--- !ruby/object:Autoloaded::InstanceClazz {}\n"


### PR DESCRIPTION
`DelayedJob` makes freedom patches of `Psych`'s `resolve_class` method.
It misses to guard this method from empty class names.

`Psych` does it:
https://github.com/tenderlove/psych/blob/2c644e18/lib/psych/class_loader.rb#L25

While deserializing an anonymous struct the class name is an empty
string (`""`). Constantizing an empty string resolves to `Object`.

This leads to this error:

```
#<NoMethodError: undefined method `members' for #<Object:0xXXXXXXX>>
```

After this commit deserializing anonymous structs works again.
