### PR TITLE
Use Thread.new to log in the Worker.start signal handler

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -133,13 +133,13 @@ module Delayed
 
     def start
       trap('TERM') do
-        say 'Exiting...'
+        Thread.new { say 'Exiting...' }
         stop
         raise SignalException.new('TERM') if self.class.raise_signal_exceptions
       end
 
       trap('INT') do
-        say 'Exiting...'
+        Thread.new { say 'Exiting...' }
         stop
         raise SignalException.new('INT') if self.class.raise_signal_exceptions && self.class.raise_signal_exceptions != :term
       end

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -72,6 +72,44 @@ describe Delayed::Worker do
     end
   end
 
+  context "worker signal trapping" do
+    it "traps a TERM" do
+      file = File.open('/tmp/dj_log', 'wb')
+      worker = Delayed::Worker.new
+      worker.logger = Logger.new(file)
+
+      pid = Process.fork do
+        worker.start
+      end
+
+      Process.kill 'TERM', pid
+      Process.wait pid
+
+      expect(File.read(file.path)).to include('Starting job worker')
+      expect(File.read(file.path)).to include('Exiting...')
+
+      File.unlink(file.path)
+    end
+
+    it "traps an INT" do
+      file = File.open('/tmp/dj_log', 'wb')
+      worker = Delayed::Worker.new
+      worker.logger = Logger.new(file)
+
+      pid = Process.fork do
+        worker.start
+      end
+
+      Process.kill 'INT', pid
+      Process.wait pid
+
+      expect(File.read(file.path)).to include('Starting job worker')
+      expect(File.read(file.path)).to include('Exiting...')
+
+      File.unlink(file.path)
+    end
+  end
+
   context "worker job reservation" do
     before do
       Delayed::Worker.exit_on_complete = true


### PR DESCRIPTION
Prevents a "log writing failed. can't be called from trap context" error
when sending a TERM or INT signal to a worker

This behavior is explained at https://bugs.ruby-lang.org/issues/7917
