### PR TITLE
Make yaml to handle anchor aliased class correctly

### DIFF
--- a/lib/delayed/psych_ext.rb
+++ b/lib/delayed/psych_ext.rb
@@ -29,14 +29,8 @@ end
 
 module Psych
   module Visitors
-    class YAMLTree
-      def visit_Class(klass)
-        @emitter.scalar klass.name, nil, '!ruby/class', false, false, Nodes::Scalar::SINGLE_QUOTED
-      end
-    end
-
     class ToRuby
-      def visit_Psych_Nodes_Scalar(o)
+      def deserialize(o)
         @st[o.anchor] = o.value if o.anchor
 
         if klass = Psych.load_tags[o.tag]

--- a/spec/yaml_ext_spec.rb
+++ b/spec/yaml_ext_spec.rb
@@ -32,4 +32,10 @@ describe "YAML" do
   it "does not throw an uninitialized constant Syck::Syck when using YAML.load with poorly formed yaml" do
     expect{ YAML.load(YAML.dump("foo: *bar"))}.not_to raise_error
   end
+
+  it "handle anchor aliased class" do
+    date = Date.new(2014, 2, 19)
+    expected = { "created_on" => date, "updated_on" => date }
+    expect(YAML.load("created_on: &1 #{date.to_s}\nupdated_on: *1")).to eq expected
+  end
 end


### PR DESCRIPTION
Currently, since `psych_ext` is based on old `psych`, aliased class is not loaded correctly.
See example below:

```
$ pry 
[1] pry(main)> require 'yaml'
=> true
[2] pry(main)> YAML.load("created_at: &1 2014-02-19 15:19:41.842913000 +09:00\nupdated_at: *1\n")
=> {"created_at"=>2014-02-19 15:19:41 +0900,
 "updated_at"=>2014-02-19 15:19:41 +0900}
[3] pry(main)> require 'delayed_job'
=> true
[4] pry(main)> YAML.load("created_at: &1 2014-02-19 15:19:41.842913000 +09:00\nupdated_at: *1\n")
=> {"created_at"=>2014-02-19 15:19:41 +0900,
 "updated_at"=>"2014-02-19 15:19:41.842913000 +09:00"}
```

I know edited lines are solving the issue of default implementation change of YAML during ruby 1.9.2/1.9.3 generation. https://github.com/collectiveidea/delayed_job/commit/14cfa873f85bfe24459202e461512216144adbce

But current code of psych does not seem to cause such issue. Please refer the current psych and review this pull request :-)

Current source of psych:
https://github.com/tenderlove/psych/blob/master/lib/psych/visitors/yaml_tree.rb
https://github.com/tenderlove/psych/blob/master/lib/psych/visitors/to_ruby.rb
