### PR TITLE
Require 'active_support/core_ext/module/attribute_accessors' instead of ...

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -1,6 +1,6 @@
 require 'timeout'
 require 'active_support/core_ext/numeric/time'
-require 'active_support/core_ext/class/attribute_accessors'
+require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/core_ext/kernel'
 require 'active_support/core_ext/enumerable'
 require 'logger'


### PR DESCRIPTION
...active_support/core_ext/class/attribute_accessors' in order to avoid deprecation warnings

[closes #620]
