### PR TITLE
Silence activesupport 4.1.x deprecation warnings.

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -1,6 +1,10 @@
 require 'timeout'
 require 'active_support/core_ext/numeric/time'
-require 'active_support/core_ext/class/attribute_accessors'
+if Gem.loaded_specs['activesupport'].version.to_s.slice(0..4) >= "4.1.0"
+  require 'active_support/core_ext/module/attribute_accessors'
+else
+  require 'active_support/core_ext/class/attribute_accessors'
+end
 require 'active_support/core_ext/kernel'
 require 'active_support/core_ext/enumerable'
 require 'logger'


### PR DESCRIPTION
This is admittedly hacky but it avoids sacrificing backwards compatibility with activesupport
4.0.x and earlier while silencing the deprecation warnings with 4.1.0.

The reason I slice the first 5 characters of the version number is to chop the `beta1` or `rc1` 
strings that throw of comparisons.
