### PR TITLE
* Modify the Worker#say method to be able to handle other loggers like Syslog/Log4r

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -243,9 +243,13 @@ module Delayed
     end
 
     def say(text, level = DEFAULT_LOG_LEVEL)
+      # This builds a hash {0=>:DEBUG, 1=>:INFO, 2=>:WARN, 3=>:ERROR, 4=>:FATAL, 5=>:UNKNOWN}
+      severities = Hash[*Logger::Severity.constants.enum_for(:each_with_index)
+                                         .collect{ |s, i| [i, s] }.flatten]
       text = "[Worker(#{name})] #{text}"
       puts text unless @quiet
-      logger.add level, "#{Time.now.strftime('%FT%T%z')}: #{text}" if logger
+      severity = severities[level].to_s.downcase
+      logger.send(severity, "#{Time.now.strftime('%FT%T%z')}: #{text}") if logger
     end
 
     def max_attempts(job)

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -99,4 +99,45 @@ describe Delayed::Worker do
       Delayed::Worker.new.work_off
     end
   end
+
+  context "#say" do
+    before(:each) do
+      @worker = Delayed::Worker.new
+      @worker.name = 'ExampleJob'
+      @worker.logger = double('job')
+      time = Time.now
+      Time.stub(:now).and_return(time)
+      @text = "Job executed"
+      @worker_name = "[Worker(ExampleJob)]"
+      @expected_time = time.strftime('%FT%T%z')
+    end
+
+    after(:each) do
+      @worker.logger = nil
+    end
+
+    shared_examples_for "a worker which logs on the correct severity" do |severity|
+      it "logs a message on the #{severity[:level].upcase} level" do
+        expect(@worker.logger).to receive(:send).
+          with(severity[:level], "#{@expected_time}: #{@worker_name} #{@text}")
+        @worker.say(@text, severity[:index])
+      end
+    end
+
+    severities = [ { index: 0, level: "debug" },
+                   { index: 1, level: "info" },
+                   { index: 2, level: "warn" },
+                   { index: 3, level: "error" },
+                   { index: 4, level: "fatal" },
+                   { index: 5, level: "unknown" } ]
+    severities.each do |severity|
+      it_behaves_like "a worker which logs on the correct severity", severity
+    end
+
+    it "logs a message on the default log's level" do
+      expect(@worker.logger).to receive(:send).
+        with("info", "#{@expected_time}: #{@worker_name} #{@text}")
+      @worker.say(@text, Delayed::Worker::DEFAULT_LOG_LEVEL)
+    end
+  end
 end


### PR DESCRIPTION
Currently is not possible to the [log4r](https://rubygems.org/gems/log4r) gem as a worker's logger as it's uses the `logger.add` method [for other purposes](https://github.com/colbygk/log4r/blob/master/lib/log4r/logger.rb#L119)

This happened when setting in a initializer the logger to use syslog like this:

```
Delayed::Worker.logger = Rails.logger
```

And when running `delayed_job` the following problem arised:

```
bundle exec rake jobs:work
[Worker(host:xrx.local pid:12424)] Starting job worker
rake aborted!
Expected kind of Outputter, got NilClass
/Users/xrx/.rvm/gems/ruby-1.9.3-p545/gems/log4r-1.1.10/lib/log4r/logger.rb:120:in `each'
/Users/xrx/.rvm/gems/ruby-1.9.3-p545/gems/log4r-1.1.10/lib/log4r/logger.rb:120:in `add'
/Users/xrx/.rvm/gems/ruby-1.9.3-p545/gems/delayed_job-4.0.0/lib/delayed/worker.rb:248:in `say'
/Users/xrx/.rvm/gems/ruby-1.9.3-p545/gems/delayed_job-4.0.0/lib/delayed/worker.rb:147:in `start'
/Users/xrx/.rvm/gems/ruby-1.9.3-p545/gems/delayed_job-4.0.0/lib/delayed/tasks.rb:9:in `block (2 levels) in <top (required)>'
Tasks: TOP => jobs:work
(See full trace by running task with --trace)
```

The idea of the patch is to log through the mapped log levels. e.g. `logger.info`, `logger.debug` and so on.

If you need more information about the problem let me know.  
