### PR TITLE
Change activesupport dependency to < 4.2

### DIFF
--- a/delayed_job.gemspec
+++ b/delayed_job.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |spec|
-  spec.add_dependency   'activesupport', ['>= 3.0', '< 4.1']
+  spec.add_dependency   'activesupport', ['>= 3.0', '< 4.2']
   spec.authors        = ["Brandon Keepers", "Brian Ryckbost", "Chris Gaffney", "David Genord II", "Erik Michaels-Ober", "Matt Griffin", "Steve Richert", "Tobias Lütke"]
   spec.description    = "Delayed_job (or DJ) encapsulates the common pattern of asynchronously executing longer tasks in the background. It is a direct extraction from Shopify where the job table is responsible for a multitude of core tasks."
   spec.email          = ['brian@collectiveidea.com']


### PR DESCRIPTION
We've been running delayed_job with Rails 4.1.0.rc in production and it worked well. Now that 4.1.0 is out the dependency specs don't match any more.

c.f. https://github.com/collectiveidea/delayed_job_active_record/pull/86
