### PR TITLE
configurable default log level

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -19,8 +19,8 @@ module Delayed
     DEFAULT_READ_AHEAD       = 5
 
     cattr_accessor :min_priority, :max_priority, :max_attempts, :max_run_time,
-      :default_priority, :sleep_delay, :logger, :delay_jobs, :queues,
-      :read_ahead, :plugins, :destroy_failed_jobs, :exit_on_complete
+      :default_priority, :default_log_level, :sleep_delay, :logger, :delay_jobs,
+      :queues, :read_ahead, :plugins, :destroy_failed_jobs, :exit_on_complete
 
     # Named queue into which jobs are enqueued by default
     cattr_accessor :default_queue_name
@@ -31,13 +31,14 @@ module Delayed
     attr_accessor :name_prefix
 
     def self.reset
-      self.sleep_delay      = DEFAULT_SLEEP_DELAY
-      self.max_attempts     = DEFAULT_MAX_ATTEMPTS
-      self.max_run_time     = DEFAULT_MAX_RUN_TIME
-      self.default_priority = DEFAULT_DEFAULT_PRIORITY
-      self.delay_jobs       = DEFAULT_DELAY_JOBS
-      self.queues           = DEFAULT_QUEUES
-      self.read_ahead       = DEFAULT_READ_AHEAD
+      self.default_log_level = DEFAULT_LOG_LEVEL
+      self.sleep_delay       = DEFAULT_SLEEP_DELAY
+      self.max_attempts      = DEFAULT_MAX_ATTEMPTS
+      self.max_run_time      = DEFAULT_MAX_RUN_TIME
+      self.default_priority  = DEFAULT_DEFAULT_PRIORITY
+      self.delay_jobs        = DEFAULT_DELAY_JOBS
+      self.queues            = DEFAULT_QUEUES
+      self.read_ahead        = DEFAULT_READ_AHEAD
     end
 
     reset
@@ -238,12 +239,12 @@ module Delayed
       end
     end
 
-    def job_say(job, text, level = DEFAULT_LOG_LEVEL)
+    def job_say(job, text, level = default_log_level)
       text = "Job #{job.name} (id=#{job.id}) #{text}"
       say text, level
     end
 
-    def say(text, level = DEFAULT_LOG_LEVEL)
+    def say(text, level = default_log_level)
       text = "[Worker(#{name})] #{text}"
       puts text unless @quiet
       if logger

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -29,7 +29,15 @@ describe Delayed::Worker do
 
     it "logs with job name and id" do
       expect(@worker).to receive(:say).
-        with('Job ExampleJob (id=123) message', Delayed::Worker::DEFAULT_LOG_LEVEL)
+        with('Job ExampleJob (id=123) message', Delayed::Worker.default_log_level)
+      @worker.job_say(@job, 'message')
+    end
+
+    it "has a configurable default log level" do
+      Delayed::Worker.default_log_level = 'error'
+
+      expect(@worker).to receive(:say).
+        with('Job ExampleJob (id=123) message', 'error')
       @worker.job_say(@job, 'message')
     end
   end
@@ -143,7 +151,7 @@ describe Delayed::Worker do
     it "logs a message on the default log's level" do
       expect(@worker.logger).to receive(:send).
         with("info", "#{@expected_time}: #{@worker_name} #{@text}")
-      @worker.say(@text, Delayed::Worker::DEFAULT_LOG_LEVEL)
+      @worker.say(@text, Delayed::Worker.default_log_level)
     end
   end
 end


### PR DESCRIPTION
Being able to configure the log level for delayed_job would be ideal.
It's a definitive need for my situation, and it will surely benefit others.

In essence, it allows users to configure the log level at the initializer level as such (in config/initializers/delayed_job.rb):
Delayed::Worker.default_log_level = :info
