### PR TITLE
Added sleep_delay and read_ahead to options for rake tasks.

### DIFF
--- a/lib/delayed/tasks.rb
+++ b/lib/delayed/tasks.rb
@@ -21,6 +21,9 @@ namespace :jobs do
       :queues => (ENV['QUEUES'] || ENV['QUEUE'] || '').split(','),
       :quiet => false
     }
+
+    @worker_options[:sleep_delay] = ENV['SLEEP_DELAY'].to_i if ENV['SLEEP_DELAY']
+    @worker_options[:read_ahead] = ENV['READ_AHEAD'].to_i if ENV['READ_AHEAD']
   end
 
   desc "Exit with error status if any jobs older than max_age seconds haven't been attempted yet."


### PR DESCRIPTION
In development I found that for a particular queue I wanted to set read_ahead separately than for other queues. 

This pull request allows me to set read_ahead and sleep_delay when launching rake task the same way I set the queue.
