### PR TITLE
allow mail rendering at delay time

### DIFF
--- a/lib/delayed/performable_mail.rb
+++ b/lib/delayed/performable_mail.rb
@@ -1,0 +1,15 @@
+require 'mail'
+
+module Delayed
+  class PerformableMail < PerformableMethod
+    def initialize(raw_mail, method_name, args)
+      super(Mail.new(raw_mail), method_name, args)
+    end
+  end
+
+  module DelayMailMessage
+    def delay(options = {})
+      DelayProxy.new(PerformableMail, encoded, options)
+    end
+  end
+end

--- a/lib/delayed/performable_mailer.rb
+++ b/lib/delayed/performable_mailer.rb
@@ -13,9 +13,3 @@ module Delayed
     end
   end
 end
-
-Mail::Message.class_eval do
-  def delay(*_args)
-    fail 'Use MyMailer.delay.mailer_action(args) to delay sending of emails.'
-  end
-end

--- a/lib/delayed/railtie.rb
+++ b/lib/delayed/railtie.rb
@@ -5,6 +5,11 @@ module Delayed
   class Railtie < Rails::Railtie
     initializer :after_initialize do
       ActiveSupport.on_load(:action_mailer) do
+        module Mail
+          class Message
+            include(Delayed::DelayMailMessage)
+          end
+        end
         ActionMailer::Base.extend(Delayed::DelayMail)
       end
     end

--- a/lib/delayed_job.rb
+++ b/lib/delayed_job.rb
@@ -6,6 +6,7 @@ require 'delayed/performable_method'
 
 if defined?(ActionMailer)
   require 'action_mailer/version'
+  require 'delayed/performable_mail'
   require 'delayed/performable_mailer'
 end
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -14,6 +14,7 @@ end
 require 'logger'
 require 'rspec'
 
+require 'mail'
 require 'action_mailer'
 require 'active_support/dependencies'
 require 'active_record'
@@ -30,6 +31,11 @@ Delayed::Worker.backend = :test
 ActiveSupport::Dependencies.autoload_paths << File.dirname(__FILE__)
 
 # Add this to simulate Railtie initializer being executed
+module Mail
+  class Message
+    include(Delayed::DelayMailMessage)
+  end
+end
 ActionMailer::Base.extend(Delayed::DelayMail)
 
 # Used to test interactions between DJ and an ORM

--- a/spec/performable_mailer_spec.rb
+++ b/spec/performable_mailer_spec.rb
@@ -20,10 +20,12 @@ describe ActionMailer::Base do
   end
 
   describe 'delay on a mail object' do
-    it 'raises an exception' do
+    it 'delays the mail object' do
       expect do
-        MyMailer.signup('john@example.com').delay
-      end.to raise_error(RuntimeError)
+        job = MyMailer.signup('john@example.com').delay.deliver
+        expect(job.payload_object.class).to eq(Delayed::PerformableMail)
+        expect(job.payload_object.method_name).to eq(:deliver)
+      end.to change { Delayed::Job.count }.by(1)
     end
   end
 


### PR DESCRIPTION
The current solution to delayed mail delivery renders the mail template at delivery time:

```
Notifier.delay.signup(@user)
```

This can lead to problems, if your data that is accessed by the mail template changed between delay time and delivery time.

When you try to explicitly delay delivery forcing rendering you will get an error:

```
Notifier.signup(@user).delay.deliver
# Use MyMailer.delay.mailer_action(args) to delay sending of emails.
```

The new approach will serialize the mail message at delay time using Mail::Message.encoded and deserialize using the constructor:

```
Notifier.signup(@user).delay.deliver
# works like expected (render message -> delay -> execute job -> deliver)
```

The old approach:

```
Notifier.delay.signup(@user)
# still works (delay -> execute job -> render message -> deliver)
```
