### PR TITLE
Remove Psych deserialization extensions

### DIFF
--- a/lib/delayed/psych_ext.rb
+++ b/lib/delayed/psych_ext.rb
@@ -31,73 +31,7 @@ end
 
 module Psych
   module Visitors
-    class YAMLTree
-      def visit_Class(klass) # rubocop:disable MethodName
-        @emitter.scalar klass.name, nil, '!ruby/class', false, false, Nodes::Scalar::SINGLE_QUOTED
-      end
-    end
-
     class ToRuby
-      def visit_Psych_Nodes_Scalar(o) # rubocop:disable CyclomaticComplexity, MethodName
-        @st[o.anchor] = o.value if o.anchor
-
-        if (klass = Psych.load_tags[o.tag])
-          instance = klass.allocate
-
-          if instance.respond_to?(:init_with)
-            coder = Psych::Coder.new(o.tag)
-            coder.scalar = o.value
-            instance.init_with coder
-          end
-
-          return instance
-        end
-
-        return o.value if o.quoted
-        return @ss.tokenize(o.value) unless o.tag
-
-        case o.tag
-        when '!binary', 'tag:yaml.org,2002:binary'
-          o.value.unpack('m').first
-        when '!str', 'tag:yaml.org,2002:str'
-          o.value
-        when '!ruby/object:DateTime'
-          require 'date'
-          @ss.parse_time(o.value).to_datetime
-        when '!ruby/object:Complex'
-          Complex(o.value)
-        when '!ruby/object:Rational'
-          Rational(o.value)
-        when '!ruby/class', '!ruby/module'
-          resolve_class o.value
-        when 'tag:yaml.org,2002:float', '!float'
-          Float(@ss.tokenize(o.value))
-        when '!ruby/regexp'
-          o.value =~ %r{^/(.*)/([mixn]*)$}
-          source  = Regexp.last_match[1]
-          options = 0
-          lang    = nil
-          (Regexp.last_match[2] || '').split('').each do |option|
-            case option
-            when 'x' then options |= Regexp::EXTENDED
-            when 'i' then options |= Regexp::IGNORECASE
-            when 'm' then options |= Regexp::MULTILINE
-            when 'n' then options |= Regexp::NOENCODING
-            else lang = option
-            end
-          end
-          Regexp.new(*[source, options, lang].compact)
-        when '!ruby/range'
-          args = o.value.split(/([.]{2,3})/, 2).collect { |s| accept Nodes::Scalar.new(s) }
-          args.push(args.delete_at(1) == '...')
-          Range.new(*args)
-        when /^!ruby\/sym(bol)?:?(.*)?$/
-          o.value.to_sym
-        else
-          @ss.tokenize o.value
-        end
-      end
-
       def visit_Psych_Nodes_Mapping_with_class(object) # rubocop:disable CyclomaticComplexity, MethodName
         return revive(Psych.load_tags[object.tag], object) if Psych.load_tags[object.tag]
 

--- a/spec/psych_ext_spec.rb
+++ b/spec/psych_ext_spec.rb
@@ -1,0 +1,12 @@
+require 'helper'
+
+describe 'Psych::Visitors::ToRuby', :if => defined?(Psych::Visitors::ToRuby) do
+  context BigDecimal do
+    it 'deserializes correctly' do
+      deserialized = YAML.load("--- !ruby/object:BigDecimal 18:0.1337E2\n...\n")
+
+      expect(deserialized).to be_an_instance_of(BigDecimal)
+      expect(deserialized).to eq(BigDecimal('13.37'))
+    end
+  end
+end


### PR DESCRIPTION
Hypothesis: we can delete the monkey patch to Psych now that delayed job focuses on ruby 1.9.3+. 

@albus522 I added the BigDecimal test case from @jarmo's patch, and all tests are passing.  #589 holds more discussion.
