### PR TITLE
Bugfix for `encode_with_override` psych extension

### DIFF
--- a/lib/delayed/psych_ext.rb
+++ b/lib/delayed/psych_ext.rb
@@ -1,14 +1,14 @@
 if defined?(ActiveRecord)
   ActiveRecord::Base.class_eval do
     if instance_methods.include?(:encode_with)
-      def encode_with_override(coder)
+      def encode_with_override(coder) # rubocop:disable BlockNesting
         encode_with_without_override(coder)
         coder.tag = "!ruby/ActiveRecord:#{self.class.name}" if coder.respond_to?(:tag=)
       end
       alias_method :encode_with_without_override, :encode_with
       alias_method :encode_with, :encode_with_override
     else
-      def encode_with(coder)
+      def encode_with(coder) # rubocop:disable BlockNesting
         coder['attributes'] = attributes
         coder.tag = "!ruby/ActiveRecord:#{self.class.name}" if coder.respond_to?(:tag=)
       end


### PR DESCRIPTION
The original PR was #609 but it had a merge conflict. If you merge this, please also close #609.

The `coder` passed to ActiveRecord::Base#encode_with does not necessarily have
a `tag=` method (it may just be a Hash). This causes issues with other callers,
eg https://github.com/Shopify/identity_cache/blob/master/lib/identity_cache/query_api.rb#L140

Conflicts:
    lib/delayed/psych_ext.rb
