### PR TITLE
Add syntax highlighting to config code docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,22 +310,22 @@ end
 
 On failure, the job is scheduled again in 5 seconds + N ** 4, where N is the number of retries.
 
-The default Worker.max_attempts is 25. After this, the job either deleted (default), or left in the database with "failed_at" set.
+The default `Worker.max_attempts` is 25. After this, the job either deleted (default), or left in the database with "failed_at" set.
 With the default of 25 attempts, the last retry will be 20 days later, with the last interval being almost 100 hours.
 
-The default Worker.max_run_time is 4.hours. If your job takes longer than that, another computer could pick it up. It's up to you to
+The default `Worker.max_run_time` is 4.hours. If your job takes longer than that, another computer could pick it up. It's up to you to
 make sure your job doesn't exceed this time. You should set this to the longest time you think the job could take.
 
 By default, it will delete failed jobs (and it always deletes successful jobs). If you want to keep failed jobs, set
-Delayed::Worker.destroy_failed_jobs = false. The failed jobs will be marked with non-null failed_at.
+`Delayed::Worker.destroy_failed_jobs = false`. The failed jobs will be marked with non-null failed_at.
 
-By default all jobs are scheduled with priority = 0, which is top priority. You can change this by setting Delayed::Worker.default_priority to something else. Lower numbers have higher priority.
+By default all jobs are scheduled with `priority = 0`, which is top priority. You can change this by setting `Delayed::Worker.default_priority` to something else. Lower numbers have higher priority.
 
-The default behavior is to read 5 jobs from the queue when finding an available job. You can configure this by setting Delayed::Worker.read_ahead.
+The default behavior is to read 5 jobs from the queue when finding an available job. You can configure this by setting `Delayed::Worker.read_ahead`.
 
-By default all jobs will be queued without a named queue. A default named queue can be specified by using Delayed::Worker.default_queue_name.
+By default all jobs will be queued without a named queue. A default named queue can be specified by using `Delayed::Worker.default_queue_name`.
 
-It is possible to disable delayed jobs for testing purposes. Set Delayed::Worker.delay_jobs = false to execute all jobs realtime.
+It is possible to disable delayed jobs for testing purposes. Set `Delayed::Worker.delay_jobs = false` to execute all jobs realtime.
 
 Here is an example of changing job parameters in Rails:
 


### PR DESCRIPTION
Skimming the "Gory Details" section, it was tough to find where the various configuration details were described.
