### PR TITLE
Improved error reporting when deserializing a non-existent record

### DIFF
--- a/lib/delayed/psych_ext.rb
+++ b/lib/delayed/psych_ext.rb
@@ -44,7 +44,7 @@ module Psych
           begin
             klass.unscoped.find(id)
           rescue ActiveRecord::RecordNotFound => error
-            raise Delayed::DeserializationError, "ActiveRecord::RecordNotFound, class: #{klass}, primary key: #{id} (#{error.message})"
+            raise(Delayed::DeserializationError.new("ActiveRecord::RecordNotFound, class: #{klass}, primary key: #{id} (#{error.message})"))
           end
         when /^!ruby\/Mongoid:(.+)$/
           klass = resolve_class(Regexp.last_match[1])
@@ -53,7 +53,7 @@ module Psych
           begin
             klass.find(id)
           rescue Mongoid::Errors::DocumentNotFound => error
-            raise Delayed::DeserializationError, "Mongoid::Errors::DocumentNotFound, class: #{klass}, primary key: #{id} (#{error.message})"
+            raise(Delayed::DeserializationError.new("Mongoid::Errors::DocumentNotFound, class: #{klass}, primary key: #{id} (#{error.message})"))
           end
         when /^!ruby\/DataMapper:(.+)$/
           klass = resolve_class(Regexp.last_match[1])
@@ -63,7 +63,7 @@ module Psych
             key_names = primary_keys.collect { |p| p.name.to_s }
             klass.get!(*key_names.collect { |k| payload['attributes'][k] })
           rescue DataMapper::ObjectNotFoundError => error
-            raise Delayed::DeserializationError, "DataMapper::ObjectNotFoundError, class: #{klass} (#{error.message})"
+            raise(Delayed::DeserializationError.new("DataMapper::ObjectNotFoundError, class: #{klass} (#{error.message})"))
           end
         else
           visit_Psych_Nodes_Mapping_without_class(object)


### PR DESCRIPTION
**DelayedJob** raises an overly generic `Delayed::DeserializationError` when it tries to load a serialized record that does not exist in the DB.
This situation can come to be because of a serialization error, or because the record has been deleted since the job was enqueued.

The error is raised because the default **YAML** behaviour of loading an object is [patched](https://github.com/collectiveidea/delayed_job/blob/master/lib/delayed/psych_ext.rb#L39) to call `klass.find(id)` if the serialized object comes from a recognized persistence library (e.g. **ActiveRecord**).

There have already been discussions about this behaviour: [#231](https://github.com/collectiveidea/delayed_job/pull/231), [#282](https://github.com/collectiveidea/delayed_job/pull/282) and [#296](https://github.com/collectiveidea/delayed_job/pull/296).
It seems like the **DJ** leads have a strong opinion on this design decision, and no patch has been merged in yet.

I'm not here to argue with the current behaviour and its implications and side effects, but I think we can do something about the error messages to make it clearer what is going on. At the moment **DJ** is catching the correct errors (e.g. `ActiveRecord::RecordNotFound`), but it's also completely discarding any information that comes with them.

This PR adds more descriptive error messages, borrowing from what has already been done [here](https://github.com/collectiveidea/delayed_job/blob/master/lib/delayed/serialization/active_record.rb#L9).
