### PR TITLE
Add encoding back to gemspec

### DIFF
--- a/delayed_job.gemspec
+++ b/delayed_job.gemspec
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', ['>= 3.0', '< 4.2']
   spec.authors        = ['Brandon Keepers', 'Brian Ryckbost', 'Chris Gaffney', 'David Genord II', 'Erik Michaels-Ober', 'Matt Griffin', 'Steve Richert', 'Tobias Lütke']


### PR DESCRIPTION
removed in 5f2b46e - will throw invalid multibyte char when loading
gemspec without it
