### PR TITLE
Address tests failures under Rails 4.2.0.beta1 - 

### DIFF
--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -23,7 +23,7 @@ require 'delayed/backend/shared_spec'
 Delayed::Worker.logger = Logger.new('/tmp/dj.log')
 ENV['RAILS_ENV'] = 'test'
 
-class Rails
+module Rails
   def self.root
     '.'
   end


### PR DESCRIPTION
Failing in travis with this: deprecated_sanitizer/version.rb:1:in `<top (required)>': Rails is not a module (TypeError) (https://travis-ci.org/collectiveidea/delayed_job/jobs/33634692)

This pull request: https://github.com/rails/rails-deprecated_sanitizer/pull/1 needs to be released as well for the tests to run, at which point, there is one failure.
