### PR TITLE
Get specs running under rails 4.2.0.beta-1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,8 @@ group :test do
   gem 'rubocop', '>= 0.25'
   gem 'simplecov', '>= 0.9'
 
-  if ENV['RAILS_VERSION'] == '4.2.0.beta1'
+  version = Gem::Requirement.parse(ENV['RAILS_VERSION']).last.version rescue nil
+  if version == '4.2.0.beta1'
     # see https://github.com/rails/rails-deprecated_sanitizer/pull/1
     gem 'rails-deprecated_sanitizer', :github => 'rails/rails-deprecated_sanitizer'
   end


### PR DESCRIPTION
The 4.2.0.beta-1 specs are failing because the released version rails-deprecated_sanitizer gem includes Rails::Railtie.  This is fixed (https://github.com/rails/rails-deprecated_sanitizer/pull/1) but not planned for release.  

This change uses the github version of rails-deprecated_sanitizer for 4.2.0.beta1

There is one failing test under 4.2.0.beta-1 when this is merged in.
