### PR TITLE
Bring back 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ env:
   global:
     - JRUBY_OPTS="$JRUBY_OPTS --debug"
   matrix:
+    - RAILS_VERSION="~> 3.0.0"
+    - RAILS_VERSION="~> 3.1.0"
     - RAILS_VERSION="~> 3.2.0"
     - RAILS_VERSION="~> 4.0.0"
     - RAILS_VERSION="~> 4.1.0"
@@ -22,4 +24,5 @@ matrix:
     - rvm: ruby-head
     - env: RAILS_VERSION="~> 4.2.0.beta1"
   fast_finish: true
+
 sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,9 @@ platforms :jruby do
 end
 
 group :test do
-  gem 'activerecord', (ENV['RAILS_VERSION'] || ['>= 3.2', '< 4.2'])
-  gem 'actionmailer', (ENV['RAILS_VERSION'] || ['>= 3.2', '< 4.2'])
-  gem 'coveralls'
+  gem 'activerecord', (ENV['RAILS_VERSION'] || ['>= 3.0', '< 4.2'])
+  gem 'actionmailer', (ENV['RAILS_VERSION'] || ['>= 3.0', '< 4.2'])
+  gem 'coveralls', :require => false
   gem 'rspec', '>= 3'
   gem 'rubocop', '>= 0.25'
   gem 'simplecov', '>= 0.9'


### PR DESCRIPTION
We should be running tests against all versions the gem claims to support and we should not drop support until we actually need to.
