### PR TITLE
Set handler in enqueue correctly

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -33,7 +33,8 @@ module Delayed
               end
             end
           else
-            Delayed::Job.new(:payload_object => options[:payload_object]).tap do |job|
+           Delayed::Job.new.tap do |job|
+              job.payload_object = options[:payload_object]
               job.invoke_job
             end
           end


### PR DESCRIPTION
When the payload_object is set via the constructor, the setter isn't called.
