### PR TITLE
Pluck emails instead of find/collect

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ NewsletterJob = Struct.new(:text, :emails) do
   end
 end
 
-Delayed::Job.enqueue NewsletterJob.new('lorem ipsum...', Customers.find(:all).collect(&:email))
+Delayed::Job.enqueue NewsletterJob.new('lorem ipsum...', Customers.pluck(:email))
 ```
 To set a per-job max attempts that overrides the Delayed::Worker.max_attempts you can define a max_attempts method on the job
 ```ruby


### PR DESCRIPTION
> Use pluck as a shortcut to select one or more attributes without
> loading a bunch of records just to grab the attributes you want.
> 
>  – http://api.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-pluck

Use `pluck` so that copy and pasted examples are faster.
