### PR TITLE
Assign the error object to the job on failure

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -63,6 +63,12 @@ module Delayed
         end
       end
 
+      attr_accessor :error
+      def error=(error)
+        @error = error
+        self.last_error = "#{error.message}\n#{error.backtrace.join("\n")}" if self.respond_to?(:last_error=)
+      end
+
       def failed?
         !!failed_at
       end

--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -500,6 +500,7 @@ shared_examples_for 'a delayed_job backend' do
         Delayed::Worker.max_run_time = 1.second
         job = Delayed::Job.create :payload_object => LongRunningJob.new
         worker.run(job)
+        expect(job.error).to_not be_nil
         expect(job.reload.last_error).to match(/expired/)
         expect(job.reload.last_error).to match(/Delayed::Worker\.max_run_time is only 1 second/)
         expect(job.attempts).to eq(1)
@@ -535,6 +536,7 @@ shared_examples_for 'a delayed_job backend' do
         Delayed::Worker.max_attempts = 1
         worker.run(@job)
         @job.reload
+        expect(@job.error).to_not be_nil
         expect(@job.last_error).to match(/did not work/)
         expect(@job.attempts).to eq(1)
         expect(@job).to be_failed
@@ -543,6 +545,7 @@ shared_examples_for 'a delayed_job backend' do
       it 're-schedules jobs after failing' do
         worker.work_off
         @job.reload
+        expect(@job.error).to_not be_nil
         expect(@job.last_error).to match(/did not work/)
         expect(@job.last_error).to match(/sample_jobs.rb:\d+:in `perform'/)
         expect(@job.attempts).to eq(1)

--- a/lib/delayed/tasks.rb
+++ b/lib/delayed/tasks.rb
@@ -19,7 +19,7 @@ namespace :jobs do
       :min_priority => ENV['MIN_PRIORITY'],
       :max_priority => ENV['MAX_PRIORITY'],
       :queues => (ENV['QUEUES'] || ENV['QUEUE'] || '').split(','),
-      :quiet => false
+      :quiet => ENV['QUIET']
     }
 
     @worker_options[:sleep_delay] = ENV['SLEEP_DELAY'].to_i if ENV['SLEEP_DELAY']

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -207,7 +207,7 @@ module Delayed
       job_say job, format('COMPLETED after %.4f', runtime)
       return true  # did work
     rescue DeserializationError => error
-      job.last_error = "#{error.message}\n#{error.backtrace.join("\n")}"
+      job.error = error
       failed(job)
     rescue => error
       self.class.lifecycle.run_callbacks(:error, self, job) { handle_failed_job(job, error) }
@@ -268,7 +268,7 @@ module Delayed
   protected
 
     def handle_failed_job(job, error)
-      job.last_error = "#{error.message}\n#{error.backtrace.join("\n")}"
+      job.error = error
       job_say job, "FAILED (#{job.attempts} prior attempts) with #{error.class.name}: #{error.message}", 'error'
       reschedule(job)
     end


### PR DESCRIPTION
Replaced `job.last_error = "...error message..."` with `job.error = error` since it is more flexible. It allow devs to store the error in their own format and failure hooks to use the job object to retrieve the error and report it properly.

`Job#error=` is a bit hacky and call `last_error=` to keep everything backward compatible, but I can remove it if you think it is ok to break current backends.

A properly way to do it would be to define the `last_error` (Or column name used to store error message) in the backend and create a message from the error attribute.