### PR TITLE
Fix undefined local variable or method `klass'

### DIFF
--- a/lib/delayed/psych_ext.rb
+++ b/lib/delayed/psych_ext.rb
@@ -34,8 +34,10 @@ module Delayed
         when /^!ruby\/object/
           result = super
           if defined?(ActiveRecord::Base) && result.is_a?(ActiveRecord::Base)
+            klass = result.class
+            id = result[klass.primary_key]
             begin
-              result.class.find(result[result.class.primary_key])
+              klass.find(id)
             rescue ActiveRecord::RecordNotFound => error # rubocop:disable BlockNesting
               raise Delayed::DeserializationError, "ActiveRecord::RecordNotFound, class: #{klass}, primary key: #{id} (#{error.message})"
             end


### PR DESCRIPTION
Jobs sometimes fail to load in 4.0.4 with the following error:

```
Job failed to load: undefined local variable or method `klass' for #<Delayed::PsychExt::ToRuby:0x007f0bd3099198>. Handler: "--- [delayed job object yaml]"
/app/vendor/bundle/ruby/2.1.0/gems/delayed_job-4.0.4/lib/delayed/backend/base.rb:87:in `rescue in payload_object'
/app/vendor/bundle/ruby/2.1.0/gems/delayed_job-4.0.4/lib/delayed/backend/base.rb:85:in `payload_object'
/app/vendor/bundle/ruby/2.1.0/gems/delayed_job-4.0.4/lib/delayed/backend/base.rb:132:in `max_run_time'
/app/vendor/bundle/ruby/2.1.0/gems/delayed_job-4.0.4/lib/delayed/worker.rb:260:in `max_run_time'
/app/vendor/bundle/ruby/2.1.0/gems/delayed_job-4.0.4/lib/delayed/worker.rb:199:in `block in run'
```

The problem is that klass and id are not defined when deserializing objects, causing an undefined error when trying to raise a DeserializationError for deleted AR objects.
