### PR TITLE
Missing 'unscoped' in psych_ext

### DIFF
--- a/lib/delayed/psych_ext.rb
+++ b/lib/delayed/psych_ext.rb
@@ -35,7 +35,7 @@ module Delayed
           result = super
           if defined?(ActiveRecord::Base) && result.is_a?(ActiveRecord::Base)
             begin
-              result.class.find(result[result.class.primary_key])
+              result.class.unscoped.find(result[result.class.primary_key])
             rescue ActiveRecord::RecordNotFound => error # rubocop:disable BlockNesting
               raise Delayed::DeserializationError, "ActiveRecord::RecordNotFound, class: #{klass}, primary key: #{id} (#{error.message})"
             end


### PR DESCRIPTION
Was broken in commit a47e0d7b55a30fb5853f20b139caddd39535727f. The find needs to be unscoped or delayed method calls with default-scoped ActiveRecord arguments do not work correctly (the same way the used to in delayed_job v.4.0.3). At least this broke our delayed_jobs...
