### PR TITLE
Add support for max_attempts option using .delay syntax

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,10 +54,6 @@ Encoding:
 EndAlignment:
   AlignWith: variable
 
-# Enforce Ruby 1.8-compatible hash syntax
-HashSyntax:
-  EnforcedStyle: hash_rockets
-
 Lambda:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,14 +17,14 @@ end
 
 group :test do
   if ENV['RAILS_VERSION'] == 'edge'
-    gem 'activerecord', :github => 'rails/rails'
-    gem 'actionmailer', :github => 'rails/rails'
+    gem 'activerecord', github: 'rails/rails'
+    gem 'actionmailer', github: 'rails/rails'
   else
     gem 'activerecord', (ENV['RAILS_VERSION'] || ['>= 3.0', '< 4.2'])
     gem 'actionmailer', (ENV['RAILS_VERSION'] || ['>= 3.0', '< 4.2'])
   end
 
-  gem 'coveralls', :require => false
+  gem 'coveralls', require: false
   gem 'rspec', '>= 3'
   gem 'rubocop', '>= 0.25'
   gem 'simplecov', '>= 0.9'

--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ end
 
 If you ever want to call a `handle_asynchronously`'d method without Delayed Job, for instance while debugging something at the console, just add `_without_delay` to the method name. For instance, if your original method was `foo`, then call `foo_without_delay`.
 
+max_attempts
+============
+`delay` accepts `max_attempts` as an option parameter. By default, the delayed job worker will retry failing jobs 24 times before giving up on the job, but you can override this behavior by specifying a `max_attempts` option. E.g.
+
+    EmailService.delay(max_attempts: 5).send_welcome_mail(user_id)
+
 Rails 3 Mailers
 ===============
 Due to how mailers are implemented in Rails 3, we had to do a little work around to get delayed_job to work.

--- a/Rakefile
+++ b/Rakefile
@@ -7,9 +7,9 @@ RSpec::Core::RakeTask.new do |r|
   r.verbose = false
 end
 
-task :test => :spec
+task test: :spec
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 
-task :default => [:spec, :rubocop]
+task default: [:spec, :rubocop]

--- a/benchmarks.rb
+++ b/benchmarks.rb
@@ -9,5 +9,5 @@ Benchmark.bm(10) do |x|
   n = 10_000
   n.times { 'foo'.delay.length }
 
-  x.report { Delayed::Worker.new(:quiet => true).work_off(n) }
+  x.report { Delayed::Worker.new(quiet: true).work_off(n) }
 end

--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -140,7 +140,7 @@ module Delayed
       end
 
       def fail!
-        update_attributes(:failed_at => self.class.db_time_now)
+        update_attributes(failed_at: self.class.db_time_now)
       end
 
     protected

--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -13,8 +13,8 @@ module Delayed
 
     def initialize(args) # rubocop:disable MethodLength
       @options = {
-        :quiet => true,
-        :pid_dir => "#{Rails.root}/tmp/pids"
+        quiet: true,
+        pid_dir: "#{Rails.root}/tmp/pids"
       }
 
       @worker_count = 1
@@ -96,7 +96,7 @@ module Delayed
     def setup_pools
       worker_index = 0
       @worker_pools.each do |queues, worker_count|
-        options = @options.merge(:queues => queues)
+        options = @options.merge(queues: queues)
         worker_count.times do
           process_name = "delayed_job.#{worker_index}"
           run_process(process_name, options)
@@ -107,7 +107,7 @@ module Delayed
 
     def run_process(process_name, options = {})
       Delayed::Worker.before_fork
-      Daemons.run_proc(process_name, :dir => options[:pid_dir], :dir_mode => :normal, :monitor => @monitor, :ARGV => @args) do |*_args|
+      Daemons.run_proc(process_name, dir: options[:pid_dir], dir_mode: :normal, monitor: @monitor, ARGV: @args) do |*_args|
         $0 = File.join(options[:prefix], process_name) if @options[:prefix]
         run process_name, options
       end

--- a/lib/delayed/lifecycle.rb
+++ b/lib/delayed/lifecycle.rb
@@ -3,13 +3,13 @@ module Delayed
 
   class Lifecycle
     EVENTS = {
-      :enqueue    => [:job],
-      :execute    => [:worker],
-      :loop       => [:worker],
-      :perform    => [:worker, :job],
-      :error      => [:worker, :job],
-      :failure    => [:worker, :job],
-      :invoke_job => [:job]
+      enqueue: [:job],
+      execute: [:worker],
+      loop: [:worker],
+      perform: [:worker, :job],
+      error: [:worker, :job],
+      failure: [:worker, :job],
+      invoke_job: [:job]
     }
 
     def initialize

--- a/lib/delayed/message_sending.rb
+++ b/lib/delayed/message_sending.rb
@@ -5,11 +5,13 @@ module Delayed
     def initialize(payload_class, target, options)
       @payload_class = payload_class
       @target = target
-      @options = options
+      @options = options.dup
+      @payload_options = options.slice(:max_attempts)
+      @options.delete(:max_attempts)
     end
 
     def method_missing(method, *args)
-      Job.enqueue({:payload_object => @payload_class.new(@target, method.to_sym, args)}.merge(@options))
+      Job.enqueue({:payload_object => @payload_class.new(@target, method.to_sym, args, @payload_options)}.merge(@options))
     end
   end
 

--- a/lib/delayed/message_sending.rb
+++ b/lib/delayed/message_sending.rb
@@ -11,7 +11,7 @@ module Delayed
     end
 
     def method_missing(method, *args)
-      Job.enqueue({:payload_object => @payload_class.new(@target, method.to_sym, args, @payload_options)}.merge(@options))
+      Job.enqueue({payload_object: @payload_class.new(@target, method.to_sym, args, @payload_options)}.merge(@options))
     end
   end
 
@@ -28,7 +28,7 @@ module Delayed
 
     def send_at(time, method, *args)
       warn '[DEPRECATION] `object.send_at(time, :method)` is deprecated. Use `object.delay(:run_at => time).method'
-      __delay__(:run_at => time).__send__(method, *args)
+      __delay__(run_at: time).__send__(method, *args)
     end
 
     module ClassMethods

--- a/lib/delayed/performable_method.rb
+++ b/lib/delayed/performable_method.rb
@@ -4,7 +4,7 @@ module Delayed
   class PerformableMethod
     attr_accessor :object, :method_name, :args, :max_attempts
 
-    delegate :method, :to => :object
+    delegate :method, to: :object
 
     def initialize(object, method_name, args, options = {})
       raise NoMethodError, "undefined method `#{method_name}' for #{object.inspect}" unless object.respond_to?(method_name, true)

--- a/lib/delayed/performable_method.rb
+++ b/lib/delayed/performable_method.rb
@@ -2,11 +2,11 @@ require 'active_support/core_ext/module/delegation'
 
 module Delayed
   class PerformableMethod
-    attr_accessor :object, :method_name, :args
+    attr_accessor :object, :method_name, :args, :max_attempts
 
     delegate :method, :to => :object
 
-    def initialize(object, method_name, args)
+    def initialize(object, method_name, args, options = {})
       raise NoMethodError, "undefined method `#{method_name}' for #{object.inspect}" unless object.respond_to?(method_name, true)
 
       if object.respond_to?(:persisted?) && !object.persisted?
@@ -16,6 +16,7 @@ module Delayed
       self.object       = object
       self.args         = args
       self.method_name  = method_name.to_sym
+      self.max_attempts = options[:max_attempts]
     end
 
     def display_name

--- a/lib/delayed/psych_ext.rb
+++ b/lib/delayed/psych_ext.rb
@@ -5,7 +5,8 @@ module Delayed
       coder.map = {
         'object' => object,
         'method_name' => method_name,
-        'args' => args
+        'args' => args,
+        'max_attempts' => max_attempts
       }
     end
   end

--- a/lib/delayed/recipes.rb
+++ b/lib/delayed/recipes.rb
@@ -37,17 +37,17 @@ Capistrano::Configuration.instance.load do
     end
 
     desc 'Stop the delayed_job process'
-    task :stop, :roles => lambda { roles } do
+    task :stop, roles: lambda { roles } do
       run "cd #{current_path};#{rails_env} #{delayed_job_command} stop #{args}"
     end
 
     desc 'Start the delayed_job process'
-    task :start, :roles => lambda { roles } do
+    task :start, roles: lambda { roles } do
       run "cd #{current_path};#{rails_env} #{delayed_job_command} start #{args}"
     end
 
     desc 'Restart the delayed_job process'
-    task :restart, :roles => lambda { roles } do
+    task :restart, roles: lambda { roles } do
       run "cd #{current_path};#{rails_env} #{delayed_job_command} restart #{args}"
     end
   end

--- a/lib/delayed/syck_ext.rb
+++ b/lib/delayed/syck_ext.rb
@@ -37,6 +37,6 @@ module YAML
   def load_dj(yaml)
     # See https://github.com/dtao/safe_yaml
     # When the method is there, we need to load our YAML like this...
-    respond_to?(:unsafe_load) ? load(yaml, :safe => false) : load(yaml)
+    respond_to?(:unsafe_load) ? load(yaml, safe: false) : load(yaml)
   end
 end

--- a/lib/delayed/tasks.rb
+++ b/lib/delayed/tasks.rb
@@ -1,25 +1,25 @@
 namespace :jobs do
   desc 'Clear the delayed_job queue.'
-  task :clear => :environment do
+  task clear: :environment do
     Delayed::Job.delete_all
   end
 
   desc 'Start a delayed_job worker.'
-  task :work => :environment_options do
+  task work: :environment_options do
     Delayed::Worker.new(@worker_options).start
   end
 
   desc 'Start a delayed_job worker and exit when all available jobs are complete.'
-  task :workoff => :environment_options do
-    Delayed::Worker.new(@worker_options.merge(:exit_on_complete => true)).start
+  task workoff: :environment_options do
+    Delayed::Worker.new(@worker_options.merge(exit_on_complete: true)).start
   end
 
-  task :environment_options => :environment do
+  task environment_options: :environment do
     @worker_options = {
-      :min_priority => ENV['MIN_PRIORITY'],
-      :max_priority => ENV['MAX_PRIORITY'],
-      :queues => (ENV['QUEUES'] || ENV['QUEUE'] || '').split(','),
-      :quiet => false
+      min_priority: ENV['MIN_PRIORITY'],
+      max_priority: ENV['MAX_PRIORITY'],
+      queues: (ENV['QUEUES'] || ENV['QUEUE'] || '').split(','),
+      quiet: false
     }
 
     @worker_options[:sleep_delay] = ENV['SLEEP_DELAY'].to_i if ENV['SLEEP_DELAY']
@@ -28,7 +28,7 @@ namespace :jobs do
 
   desc "Exit with error status if any jobs older than max_age seconds haven't been attempted yet."
   task :check, [:max_age] => :environment do |_, args|
-    args.with_defaults(:max_age => 300)
+    args.with_defaults(max_age: 300)
 
     unprocessed_jobs = Delayed::Job.where('attempts = 0 AND created_at < ?', Time.now - args[:max_age].to_i).count
 

--- a/spec/delayed/command_spec.rb
+++ b/spec/delayed/command_spec.rb
@@ -40,13 +40,13 @@ describe Delayed::Command do
       expect(Dir).to receive(:mkdir).with('./tmp/pids').once
 
       [
-        ['delayed_job.0', {:quiet => true, :pid_dir => './tmp/pids', :queues => []}],
-        ['delayed_job.1', {:quiet => true, :pid_dir => './tmp/pids', :queues => ['test_queue']}],
-        ['delayed_job.2', {:quiet => true, :pid_dir => './tmp/pids', :queues => ['test_queue']}],
-        ['delayed_job.3', {:quiet => true, :pid_dir => './tmp/pids', :queues => ['test_queue']}],
-        ['delayed_job.4', {:quiet => true, :pid_dir => './tmp/pids', :queues => ['test_queue']}],
-        ['delayed_job.5', {:quiet => true, :pid_dir => './tmp/pids', :queues => %w[mailers misc]}],
-        ['delayed_job.6', {:quiet => true, :pid_dir => './tmp/pids', :queues => %w[mailers misc]}]
+        ['delayed_job.0', {quiet: true, pid_dir: './tmp/pids', queues: []}],
+        ['delayed_job.1', {quiet: true, pid_dir: './tmp/pids', queues: ['test_queue']}],
+        ['delayed_job.2', {quiet: true, pid_dir: './tmp/pids', queues: ['test_queue']}],
+        ['delayed_job.3', {quiet: true, pid_dir: './tmp/pids', queues: ['test_queue']}],
+        ['delayed_job.4', {quiet: true, pid_dir: './tmp/pids', queues: ['test_queue']}],
+        ['delayed_job.5', {quiet: true, pid_dir: './tmp/pids', queues: %w[mailers misc]}],
+        ['delayed_job.6', {quiet: true, pid_dir: './tmp/pids', queues: %w[mailers misc]}]
       ].each do |args|
         expect(command).to receive(:run_process).with(*args).once
       end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -49,14 +49,14 @@ ActiveSupport::Dependencies.autoload_paths << File.dirname(__FILE__)
 ActionMailer::Base.extend(Delayed::DelayMail)
 
 # Used to test interactions between DJ and an ORM
-ActiveRecord::Base.establish_connection :adapter => 'sqlite3', :database => ':memory:'
+ActiveRecord::Base.establish_connection adapter: 'sqlite3', database: ':memory:'
 ActiveRecord::Base.logger = Delayed::Worker.logger
 ActiveRecord::Migration.verbose = false
 
 ActiveRecord::Schema.define do
-  create_table :stories, :primary_key => :story_id, :force => true do |table|
+  create_table :stories, primary_key: :story_id, force: true do |table|
     table.string :text
-    table.boolean :scoped, :default => true
+    table.boolean :scoped, default: true
   end
 end
 
@@ -69,7 +69,7 @@ class Story < ActiveRecord::Base
   def whatever(n, _)
     tell * n
   end
-  default_scope { where(:scoped => true) }
+  default_scope { where(scoped: true) }
 
   handle_asynchronously :whatever
 end

--- a/spec/message_sending_spec.rb
+++ b/spec/message_sending_spec.rb
@@ -26,7 +26,7 @@ describe Delayed::MessageSending do
       class Fable
         cattr_accessor :importance
         def tell; end
-        handle_asynchronously :tell, :priority => proc { importance }
+        handle_asynchronously :tell, priority: proc { importance }
       end
 
       it 'sets the priority based on the Fable importance' do
@@ -44,7 +44,7 @@ describe Delayed::MessageSending do
           attr_accessor :importance
           def spin
           end
-          handle_asynchronously :spin, :priority => proc { |y| y.importance }
+          handle_asynchronously :spin, priority: proc { |y| y.importance }
         end
 
         it 'sets the priority based on the Fable importance' do
@@ -94,7 +94,7 @@ describe Delayed::MessageSending do
 
     it 'sets job options' do
       run_at = Time.parse('2010-05-03 12:55 AM')
-      job = FairyTail.delay(:priority => 20, :run_at => run_at).to_s
+      job = FairyTail.delay(priority: 20, run_at: run_at).to_s
       expect(job.run_at).to eq(run_at)
       expect(job.priority).to eq(20)
     end

--- a/spec/message_sending_spec.rb
+++ b/spec/message_sending_spec.rb
@@ -118,5 +118,11 @@ describe Delayed::MessageSending do
         end.not_to change(fairy_tail, :happy_ending)
       end.to change { Delayed::Job.count }.by(1)
     end
+
+    it 'passes max_attempts to payload object as option if provided' do
+      expect(Delayed::PerformableMethod).to receive(:new).with(String, :constants, [], max_attempts: 5).and_call_original
+      String.delay(max_attempts: 5).constants
+    end
+
   end
 end

--- a/spec/performable_mailer_spec.rb
+++ b/spec/performable_mailer_spec.rb
@@ -3,7 +3,7 @@ require 'helper'
 require 'action_mailer'
 class MyMailer < ActionMailer::Base
   def signup(email)
-    mail :to => email, :subject => 'Delaying Emails', :from => 'delayedjob@example.com', :body => 'Delaying Emails Body'
+    mail to: email, subject: 'Delaying Emails', from: 'delayedjob@example.com', body: 'Delaying Emails Body'
   end
 end
 
@@ -30,8 +30,8 @@ describe ActionMailer::Base do
   describe Delayed::PerformableMailer do
     describe 'perform' do
       it 'calls the method and #deliver on the mailer' do
-        email = double('email', :deliver => true)
-        mailer_class = double('MailerClass', :signup => email)
+        email = double('email', deliver: true)
+        mailer_class = double('MailerClass', signup: email)
         mailer = Delayed::PerformableMailer.new(mailer_class, :signup, ['john@example.com'])
 
         expect(mailer_class).to receive(:signup).with('john@example.com')

--- a/spec/performable_method_spec.rb
+++ b/spec/performable_method_spec.rb
@@ -22,6 +22,20 @@ describe Delayed::PerformableMethod do
     end
   end
 
+  context 'max_attempts' do
+
+    it 'returns a value if provided through options' do
+      payload_object = Delayed::PerformableMethod.new(String, :constants, [], max_attempts: 5)
+      expect(payload_object.max_attempts).to eql 5
+    end
+
+    it 'returns nil if no value is provided through options' do
+      payload_object = Delayed::PerformableMethod.new(String, :constants, [])
+      expect(payload_object.max_attempts).to eql nil
+    end
+
+  end
+
   it "raises a NoMethodError if target method doesn't exist" do
     expect do
       Delayed::PerformableMethod.new(Object, :method_that_does_not_exist, [])

--- a/spec/performable_method_spec.rb
+++ b/spec/performable_method_spec.rb
@@ -122,4 +122,12 @@ describe Delayed::PerformableMethod do
       end
     end
   end
+
+  it 'serializes correctly' do
+    original_payload_object = Delayed::PerformableMethod.new(String, :constants, [], max_attempts: 5)
+    serialized_payload_object = original_payload_object.to_yaml
+    deserialized_payload_object = YAML.load_dj(serialized_payload_object)
+    expect(deserialized_payload_object.max_attempts).to eql 5
+  end
+
 end

--- a/spec/psych_ext_spec.rb
+++ b/spec/psych_ext_spec.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-describe 'Psych::Visitors::ToRuby', :if => defined?(Psych::Visitors::ToRuby) do
+describe 'Psych::Visitors::ToRuby', if: defined?(Psych::Visitors::ToRuby) do
   context BigDecimal do
     it 'deserializes correctly' do
       deserialized = YAML.load("--- !ruby/object:BigDecimal 18:0.1337E2\n...\n")

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -24,7 +24,7 @@ describe Delayed::Worker do
   describe 'job_say' do
     before do
       @worker = Delayed::Worker.new
-      @job = double('job', :id => 123, :name => 'ExampleJob')
+      @job = double('job', id: 123, name: 'ExampleJob')
     end
 
     it 'logs with job name and id' do
@@ -138,12 +138,12 @@ describe Delayed::Worker do
       end
     end
 
-    severities = [{:index => 0, :level => 'debug'},
-                  {:index => 1, :level => 'info'},
-                  {:index => 2, :level => 'warn'},
-                  {:index => 3, :level => 'error'},
-                  {:index => 4, :level => 'fatal'},
-                  {:index => 5, :level => 'unknown'}]
+    severities = [{index: 0, level: 'debug'},
+                  {index: 1, level: 'info'},
+                  {index: 2, level: 'warn'},
+                  {index: 3, level: 'error'},
+                  {index: 4, level: 'fatal'},
+                  {index: 5, level: 'unknown'}]
     severities.each do |severity|
       it_behaves_like 'a worker which logs on the correct severity', severity
     end


### PR DESCRIPTION
These changes will allow you use max_attempts as an option when scheduling with the delay syntax. E.g.

    EmailService.delay(max_attempts: 5).send_welcome_mail(user.id)

See issue here: https://github.com/collectiveidea/delayed_job/issues/736

During the coding, I discovered that the serialization routines appears to be vaguely tested, at least for `PerformableMethod`. I've added an example where I spec the proper serialization of the `max_attempts` option, but I'm uncertain if it is relevant. So I'd be happy with some thoughts on the following questions

1) Should YAML serialization for PerformableMethod be tested?
2) If so, how to go about it?
3) Especially with regards to multiple YAML serializers... Perhaps it's time to abandon Syck and go for Psych support only?