### PR TITLE
Protect from monkey patched ActiveRecord::Base.find

### DIFF
--- a/lib/delayed/psych_ext.rb
+++ b/lib/delayed/psych_ext.rb
@@ -35,7 +35,7 @@ module Delayed
           result = super
           if defined?(ActiveRecord::Base) && result.is_a?(ActiveRecord::Base)
             begin
-              result.class.find(result[result.class.primary_key])
+              result.class.find_by!(result.class.primary_key => result[result.class.primary_key])
             rescue ActiveRecord::RecordNotFound => error # rubocop:disable BlockNesting
               raise Delayed::DeserializationError, "ActiveRecord::RecordNotFound, class: #{klass}, primary key: #{id} (#{error.message})"
             end


### PR DESCRIPTION
I inherited a project that uses the obfuscate_id gem, which patches ActiveRecord's find method so it can obfuscate and deobfuscate ids transparently. When upgrading from delayed_job 4.0.3 to 4.0.4 we found that ids were being erroneously obfuscated when delayed_job tries to load the record.

This patch should help users of obfuscate_id and other gems that monkey around with ActiveRecord's find method.