### PR TITLE
Allow a queue name of NULL to mean "do jobs with no queue specified"

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,10 @@ Work off queues by setting the `QUEUE` or `QUEUES` environment variable.
     QUEUE=tracking rake jobs:work
     QUEUES=mailers,tasks rake jobs:work
 
+Specify a queue name of NULL to allow a worker to do jobs that have no queue specified:
+
+    QUEUES=mailers,NULL rake jobs:work
+
 Restarting delayed_job
 ======================
 

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -18,7 +18,7 @@ module Delayed
     DEFAULT_READ_AHEAD       = 5
 
     cattr_accessor :min_priority, :max_priority, :max_attempts, :max_run_time,
-                   :default_priority, :sleep_delay, :logger, :delay_jobs, :queues,
+                   :default_priority, :sleep_delay, :logger, :delay_jobs,
                    :read_ahead, :plugins, :destroy_failed_jobs, :exit_on_complete,
                    :default_log_level
 
@@ -29,6 +29,21 @@ module Delayed
 
     # name_prefix is ignored if name is set directly
     attr_accessor :name_prefix
+
+    class << self
+      attr_reader :queues
+      def queues=(queues)
+        @queues = queues.map { |q| q == 'NULL' ? nil : q }
+      end
+    end
+
+    def queues
+      self.class.queues
+    end
+
+    def queues=(queues)
+      self.class.queues = queues
+    end
 
     def self.reset
       self.default_log_level = DEFAULT_LOG_LEVEL

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -21,6 +21,15 @@ describe Delayed::Worker do
     end
   end
 
+  describe 'queues=' do
+    before do
+      Delayed::Worker.queues = %w[mailers NULL]
+    end
+    it 'sets the array to include nil' do
+      expect(Delayed::Worker.queues).to eq(['mailers', nil])
+    end
+  end
+
   describe 'job_say' do
     before do
       @worker = Delayed::Worker.new


### PR DESCRIPTION
fixes #425 

(This replaces pull request #457, rebased, adapted to new docs, cleaned up new lint tests.)
