### PR TITLE
Allow delay_jobs configuration to be a proc

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,14 @@ By default all jobs will be queued without a named queue. A default named queue 
 
 It is possible to disable delayed jobs for testing purposes. Set `Delayed::Worker.delay_jobs = false` to execute all jobs realtime.
 
+Or `Delayed::Worker.delay_jobs` can be a Proc that decides whether to execute jobs inline on a per-job basis:
+
+```ruby
+Delayed::Worker.delay_jobs = ->(job) {
+  job.queue != 'inline'
+}
+```
+
 You may need to raise exceptions on SIGTERM signals, `Delayed::Worker.raise_signal_exceptions = :term` will cause the worker to raise a `SignalException` causing the running job to abort and be unlocked, which makes the job available to other workers. The default for this option is false.
 
 Here is an example of changing job parameters in Rails:

--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -32,7 +32,7 @@ module Delayed
           new(options).tap do |job|
             Delayed::Worker.lifecycle.run_callbacks(:enqueue, job) do
               job.hook(:enqueue)
-              Delayed::Worker.delay_jobs ? job.save : job.invoke_job
+              job.should_really_delay? ? job.save : job.invoke_job
             end
           end
         end
@@ -60,6 +60,14 @@ module Delayed
         def work_off(num = 100)
           warn '[DEPRECATION] `Delayed::Job.work_off` is deprecated. Use `Delayed::Worker.new.work_off instead.'
           Delayed::Worker.new.work_off(num)
+        end
+      end
+
+      def should_really_delay?
+        if Delayed::Worker.delay_jobs.is_a?(Proc)
+          Delayed::Worker.delay_jobs.call(self)
+        else
+          Delayed::Worker.delay_jobs
         end
       end
 

--- a/spec/message_sending_spec.rb
+++ b/spec/message_sending_spec.rb
@@ -118,5 +118,25 @@ describe Delayed::MessageSending do
         end.not_to change(fairy_tail, :happy_ending)
       end.to change { Delayed::Job.count }.by(1)
     end
+
+    it 'does delay when delay_jobs is a proc returning true' do
+      Delayed::Worker.delay_jobs = ->(_job) { true }
+      fairy_tail = FairyTail.new
+      expect do
+        expect do
+          fairy_tail.delay.tell
+        end.not_to change(fairy_tail, :happy_ending)
+      end.to change { Delayed::Job.count }.by(1)
+    end
+
+    it 'does not delay the job when delay_jobs is a proc returning false' do
+      Delayed::Worker.delay_jobs = ->(_job) { false }
+      fairy_tail = FairyTail.new
+      expect do
+        expect do
+          fairy_tail.delay.tell
+        end.to change(fairy_tail, :happy_ending).from(nil).to(true)
+      end.not_to change { Delayed::Job.count }
+    end
   end
 end


### PR DESCRIPTION
decide whether to background one job at a time