### PR TITLE
Rescue all exceptions, re-raise as a StandardError

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -93,7 +93,7 @@ module Delayed
             hook :before
             payload_object.perform
             hook :success
-          rescue Exception => e
+          rescue Exception => e # rubocop:disable RescueException
             hook :error, e
             if e.class == Exception
               raise StandardError, e.message

--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -93,9 +93,13 @@ module Delayed
             hook :before
             payload_object.perform
             hook :success
-          rescue => e
+          rescue Exception => e
             hook :error, e
-            raise e
+            if e.class == Exception
+              raise StandardError, e.message
+            else
+              raise e
+            end
           ensure
             hook :after
           end


### PR DESCRIPTION
Addresses #741 

Does this change look OK to you? After upgrading from DJ 4.0.0 to 4.0.6 we started having some issues with error handling. This seems to fix the issues for us. I'm happy to add tests shortly to help explain further.

Tests fail because of a rubocop violation. I think this merits a rubocop exception