### PR TITLE
Add ability to set destroy failed jobs on a per job basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ NewsletterJob = Struct.new(:text, :emails) do
 end
 ```
 
-To set a per-job default for destroying failed jobs that overrides the Delayed::Worker.destroy_failed_jobs you can define a destroy_failed_jobs method on the job
+To set a per-job default for destroying failed jobs that overrides the Delayed::Worker.destroy_failed_jobs you can define a destroy_failed_jobs? method on the job
 
 ```ruby
 NewsletterJob = Struct.new(:text, :emails) do
@@ -302,7 +302,7 @@ NewsletterJob = Struct.new(:text, :emails) do
     emails.each { |e| NewsletterMailer.deliver_text_to_email(text, e) }
   end
 
-  def destroy_failed_jobs
+  def destroy_failed_jobs?
     false
   end
 end

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ NewsletterJob = Struct.new(:text, :emails) do
 end
 ```
 
-To set a per-job default for destorying failed jobs that overrides the Delayed::Worker.destroy_failed_jobs you can define a destroy_failed_jobs method on the job
+To set a per-job default for destroying failed jobs that overrides the Delayed::Worker.destroy_failed_jobs you can define a destroy_failed_jobs method on the job
 
 ```ruby
 NewsletterJob = Struct.new(:text, :emails) do

--- a/README.md
+++ b/README.md
@@ -294,6 +294,20 @@ NewsletterJob = Struct.new(:text, :emails) do
 end
 ```
 
+To set a per-job default for destorying failed jobs that overrides the Delayed::Worker.destroy_failed_jobs you can define a destroy_failed_jobs method on the job
+
+```ruby
+NewsletterJob = Struct.new(:text, :emails) do
+  def perform
+    emails.each { |e| NewsletterMailer.deliver_text_to_email(text, e) }
+  end
+
+  def destroy_failed_jobs
+    false
+  end
+end
+```
+
 To set a default queue name for a custom job that overrides Delayed::Worker.default_queue_name, you can define a queue_name method on the job
 
 ```ruby

--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -139,6 +139,10 @@ module Delayed
         end
       end
 
+      def destroy_failed_jobs
+        payload_object.destroy_failed_jobs if payload_object.respond_to?(:destroy_failed_jobs)
+      end
+
       def fail!
         update_attributes(:failed_at => self.class.db_time_now)
       end

--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -139,8 +139,8 @@ module Delayed
         end
       end
 
-      def destroy_failed_jobs
-        payload_object.destroy_failed_jobs if payload_object.respond_to?(:destroy_failed_jobs)
+      def destroy_failed_jobs?
+        payload_object.respond_to?(:destroy_failed_jobs?) ? payload_object.destroy_failed_jobs? : Delayed::Worker.destroy_failed_jobs
       end
 
       def fail!

--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -677,7 +677,7 @@ shared_examples_for 'a delayed_job backend' do
 
         it_behaves_like 'any failure more than Worker.max_attempts times'
 
-        context "and destroy failed jobs is false" do
+        context 'and destroy failed jobs is false' do
           it 'is failed if it failed more than Worker.max_attempts times' do
             expect(@job.reload).not_to be_failed
             Delayed::Worker.max_attempts.times { worker.reschedule(@job) }
@@ -690,7 +690,7 @@ shared_examples_for 'a delayed_job backend' do
           end
         end
 
-        context "and destroy failed jobs for job is false" do
+        context 'and destroy failed jobs for job is false' do
           before do
             Delayed::Worker.destroy_failed_jobs = true
           end

--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -460,17 +460,17 @@ shared_examples_for 'a delayed_job backend' do
     end
 
     it 'results in the default destroy failed jobs setting when not defined' do
-      expect(worker.destroy_failed_jobs(@job)).to eq(Delayed::Worker::DEFAULT_DESTROY_FAILED_JOBS)
+      expect(worker.destroy_failed_jobs(@job)).to be true
     end
 
     it 'uses the destroy failed jobs value on the payload when defined' do
       expect(@job.payload_object).to receive(:destroy_failed_jobs).and_return(true)
-      expect(@job.destroy_failed_jobs).to be_truthy
+      expect(@job.destroy_failed_jobs).to be true
     end
 
     it 'results in an overridden destroy failed jobs value when defined' do
       expect(@job.payload_object).to receive(:destroy_failed_jobs).and_return(true).twice
-      expect(worker.destroy_failed_jobs(@job)).to be_truthy
+      expect(worker.destroy_failed_jobs(@job)).to be true
     end
   end
 

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -16,7 +16,6 @@ module Delayed
     DEFAULT_DELAY_JOBS       = true
     DEFAULT_QUEUES           = []
     DEFAULT_READ_AHEAD       = 5
-    DEFAULT_DESTROY_FAILED_JOBS = true
 
     cattr_accessor :min_priority, :max_priority, :max_attempts, :max_run_time,
                    :default_priority, :sleep_delay, :logger, :delay_jobs, :queues,
@@ -40,7 +39,6 @@ module Delayed
       self.delay_jobs        = DEFAULT_DELAY_JOBS
       self.queues            = DEFAULT_QUEUES
       self.read_ahead        = DEFAULT_READ_AHEAD
-      self.destroy_failed_jobs = DEFAULT_DESTROY_FAILED_JOBS
       @lifecycle             = nil
     end
 
@@ -48,6 +46,10 @@ module Delayed
 
     # Add or remove plugins in this list before the worker is instantiated
     self.plugins = [Delayed::Plugins::ClearLocks]
+
+    # By default failed jobs are destroyed after too many attempts. If you want to keep them around
+    # (perhaps to inspect the reason for the failure), set this to false.
+    self.destroy_failed_jobs = true
 
     # By default, Signals INT and TERM set @exit, and the worker exits upon completion of the current job.
     # If you would prefer to raise a SignalException and exit immediately you can use this.

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -247,7 +247,7 @@ module Delayed
           say "Error when running failure callback: #{error}", 'error'
           say error.backtrace.join("\n"), 'error'
         ensure
-          destroy_failed_jobs(job) ? job.destroy : job.fail!
+          job.destroy_failed_jobs? ? job.destroy : job.fail!
         end
       end
     end
@@ -274,10 +274,6 @@ module Delayed
 
     def max_run_time(job)
       job.max_run_time || self.class.max_run_time
-    end
-
-    def destroy_failed_jobs(job)
-      job.destroy_failed_jobs.nil? ? self.class.destroy_failed_jobs : job.destroy_failed_jobs
     end
 
   protected


### PR DESCRIPTION
We recently needed the ability to selectively delete failed jobs, even though our default is to keep all failed jobs.  I noticed there was a pull request (#742) but it has been sitting for a few months without tests.  I went ahead and built out the feature with tests included and I updated the README with an example.  DJ has been a real work horse for us for a number of years now, and I appreciate all the work you've done maintaining it.