### PR TITLE
Catch all kinds of `Exception` not `StandardError` only

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -209,7 +209,7 @@ module Delayed
     rescue DeserializationError => error
       job.last_error = "#{error.message}\n#{error.backtrace.join("\n")}"
       failed(job)
-    rescue => error
+    rescue Exception => error
       self.class.lifecycle.run_callbacks(:error, self, job) { handle_failed_job(job, error) }
       return false  # work failed
     end


### PR DESCRIPTION
Currently only `StandardError` exceptions are caught by `Delayed::Worker#run`, raising an `Exception` while processing a job causes that worker is crashing.