### PR TITLE
Make Delayed::Worker.new idempotent

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -39,6 +39,7 @@ module Delayed
       self.delay_jobs        = DEFAULT_DELAY_JOBS
       self.queues            = DEFAULT_QUEUES
       self.read_ahead        = DEFAULT_READ_AHEAD
+      @lifecycle             = nil
     end
 
     reset
@@ -97,7 +98,15 @@ module Delayed
     end
 
     def self.lifecycle
-      @lifecycle ||= Delayed::Lifecycle.new
+      # In case a worker has not been set up, job enqueueing needs a lifecycle.
+      setup_lifecycle unless @lifecycle
+
+      @lifecycle
+    end
+
+    def self.setup_lifecycle
+      @lifecycle = Delayed::Lifecycle.new
+      plugins.each { |klass| klass.new }
     end
 
     def self.reload_app?
@@ -112,7 +121,9 @@ module Delayed
         self.class.send("#{option}=", options[option]) if options.key?(option)
       end
 
-      plugins.each { |klass| klass.new }
+      # Reset lifecycle on the offhand chance that something lazily
+      # triggered its creation before all plugins had been registered.
+      self.class.setup_lifecycle
     end
 
     # Every worker has a unique name which by default is the pid of the process. There are some

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -154,4 +154,22 @@ describe Delayed::Worker do
       @worker.say(@text, Delayed::Worker.default_log_level)
     end
   end
+
+  describe 'plugin registration' do
+    it 'does not double-register plugins on worker instantiation' do
+      performances = 0
+      plugin = Class.new(Delayed::Plugin) do
+        callbacks do |lifecycle|
+          lifecycle.before(:enqueue) { performances += 1 }
+        end
+      end
+      Delayed::Worker.plugins << plugin
+
+      Delayed::Worker.new
+      Delayed::Worker.new
+      Delayed::Worker.lifecycle.run_callbacks(:enqueue, nil) {}
+
+      expect(performances).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
Calling Delayed::Worker.new multiple times would continue to re-add the plugins to the lifecycle.

Some gems and projects use the pattern `Delayed::Worker.new.work_off` to trigger delayed jobs in specs. Over time, as each call to `.new` added more callbacks to the chain, the callback chain would get very long and, in our case, caused a StackLevelTooDeep error.

Better would be to have a proper singleton: 

```ruby
Delayed::Worker.worker.work_off
```

In the absence of a proper singleton, this PR will make the pattern work: the lifecycle is re-initialized from the plugins list on instantiation.

For the `enqueue` action, which can accept callbacks but may happen in an application context where no worker has been instantiated, the lifecycle is lazily initialized from the plugins.