### PR TITLE
Point ActiveRecord to the same log as the delayed job log

### DIFF
--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -119,7 +119,7 @@ module Delayed
       Delayed::Worker.after_fork
       Delayed::Worker.logger ||= Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))
       
-      ActiveRecord::Base.logger = Delayed::Worker.logger if Delayed::Worker.backend == :active_record
+      ActiveRecord::Base.logger = Delayed::Worker.logger if Delayed::Worker.backend.new.is_a? Delayed::Backend::ActiveRecord::Job
 
       worker = Delayed::Worker.new(options)
       worker.name_prefix = "#{worker_name} "

--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -118,7 +118,7 @@ module Delayed
 
       Delayed::Worker.after_fork
       Delayed::Worker.logger ||= Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))
-      
+
       ActiveRecord::Base.logger = Delayed::Worker.logger if Delayed::Worker.backend.new.is_a? Delayed::Backend::ActiveRecord::Job
 
       worker = Delayed::Worker.new(options)

--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -118,6 +118,8 @@ module Delayed
 
       Delayed::Worker.after_fork
       Delayed::Worker.logger ||= Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))
+      
+      ActiveRecord::Base.logger = Delayed::Worker.logger if Delayed::Worker.backend == :active_record
 
       worker = Delayed::Worker.new(options)
       worker.name_prefix = "#{worker_name} "


### PR DESCRIPTION
Sending this PR as a concept, for getting feedback. If we agree, I will cleanup / test and re-submit. I looked at the delayed_job_active_record gem code to see if there is a better place to plug this in, but couldn't see it. Since that code executes in both worker as well as [rails] app processes, we need to be careful in when we override the `ActiveRecord` logger.