### PR TITLE
Proposal: singleton delayed jobs.

### DIFF
--- a/lib/delayed/message_sending.rb
+++ b/lib/delayed/message_sending.rb
@@ -8,8 +8,16 @@ module Delayed
       @options = options
     end
 
+    def once
+      @options ||= {}
+      @options[:once] = true
+      self
+    end
+
     def method_missing(method, *args)
-      Job.enqueue({:payload_object => @payload_class.new(@target, method.to_sym, args)}.merge(@options))
+      singleton_job = @options.delete(:once) if @options
+      options = {:payload_object => @payload_class.new(@target, method.to_sym, args)}.merge(@options)
+      singleton_job ? Job.enqueue_once(options) : Job.enqueue(options)
     end
   end
 


### PR DESCRIPTION
We use delayed job to continuously index in the background, for example with ElasticSearch. Every time an instance changes, we queue a job.

That adds up quickly. We'd like to queue a job, and not queue the same one again as long as there's already a queued one. 

We use MongoDB, so this is even possible atomically with an `upsert`, however this is rarely needed since delayed jobs in our case get queued after something is saved, so if we see something still queued, it will for sure pickup the update we just made.

This is a rough refactoring that introduces the concept into DJ. I'd like to figure out whether this is a good idea and whether the interface looks crazy before writing tests and things like that. As far as the public interface is concerned so far, this would mean having to implement `find_one` on a back-end.