### PR TITLE
Catch DeserializationError in destroy_failed_jobs

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -147,6 +147,8 @@ module Delayed
 
       def destroy_failed_jobs?
         payload_object.respond_to?(:destroy_failed_jobs?) ? payload_object.destroy_failed_jobs? : Delayed::Worker.destroy_failed_jobs
+      rescue DeserializationError
+        Delayed::Worker.destroy_failed_jobs
       end
 
       def fail!

--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -529,7 +529,6 @@ shared_examples_for 'a delayed_job backend' do
         it 'marks the job as failed' do
           Delayed::Worker.destroy_failed_jobs = false
           job = described_class.create! :handler => '--- !ruby/object:JobThatDoesNotExist {}'
-          expect(job).to receive(:destroy_failed_jobs?).and_return(false)
           worker.work_off
           job.reload
           expect(job).to be_failed


### PR DESCRIPTION
Since #770, deserialization errors will take down DelayedJob because the exception gets raised outside of the regular rescue blocks.  How about this PR?