### PR TITLE
Rescue exception in worker (now with fixed rubocop warning)

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -228,7 +228,7 @@ module Delayed
     rescue DeserializationError => error
       job.error = error
       failed(job)
-    rescue => error
+    rescue Exception => error
       self.class.lifecycle.run_callbacks(:error, self, job) { handle_failed_job(job, error) }
       return false  # work failed
     end

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -228,7 +228,7 @@ module Delayed
     rescue DeserializationError => error
       job.error = error
       failed(job)
-    rescue Exception => error
+    rescue Exception => error # rubocop:disable RescueException
       self.class.lifecycle.run_callbacks(:error, self, job) { handle_failed_job(job, error) }
       return false  # work failed
     end

--- a/spec/sample_jobs.rb
+++ b/spec/sample_jobs.rb
@@ -23,7 +23,7 @@ class ErrorJob
   cattr_accessor :runs
   @runs = 0
   def perform
-    raise 'did not work'
+    raise Exception, 'did not work'
   end
 end
 


### PR DESCRIPTION
The [commit](https://github.com/collectiveidea/delayed_job/commit/02f76e6111496132096f901920ba4dff1f86234e) for issue #741 did not fix the problem of delayed_job worker process crashing on exceptions of type `Exception` for me.

If I change the [sample job](https://github.com/collectiveidea/delayed_job/blob/fec3706cf19b93899e05e607135a5b8b6e89b8c1/spec/sample_jobs.rb#L26) to raise an `Exception` instead of `StandardError` the delayed_job tests break...

I think the [worker](https://github.com/collectiveidea/delayed_job/blob/ce88693429188a63793b16daaab67056a4e4e0bf/lib/delayed/worker.rb#L231) has also to rescue exceptions of class `Exception`.
