### PR TITLE
Do not use ClassMethods constant name when extending Object

### DIFF
--- a/lib/delayed/message_sending.rb
+++ b/lib/delayed/message_sending.rb
@@ -29,7 +29,7 @@ module Delayed
       __delay__(:run_at => time).__send__(method, *args)
     end
 
-    module ClassMethods
+    module AsynchronousClassMethods
       def handle_asynchronously(method, opts = {})
         aliased_method, punctuation = method.to_s.sub(/([?!=])$/, ''), $1 # rubocop:disable PerlBackrefs
         with_method, without_method = "#{aliased_method}_with_delay#{punctuation}", "#{aliased_method}_without_delay#{punctuation}"

--- a/lib/delayed_job.rb
+++ b/lib/delayed_job.rb
@@ -19,4 +19,4 @@ require 'delayed/deserialization_error'
 require 'delayed/railtie' if defined?(Rails::Railtie)
 
 Object.send(:include, Delayed::MessageSending)
-Module.send(:include, Delayed::MessageSending::ClassMethods)
+Module.send(:include, Delayed::MessageSending::AsynchronousClassMethods)

--- a/spec/active_support_concern_spec.rb
+++ b/spec/active_support_concern_spec.rb
@@ -5,7 +5,7 @@ describe 'ActiveSupport::Concern' do
     module TestConcern
       extend ActiveSupport::Concern
 
-      class_methods do
+      module ClassMethods
         def concern_test_method
         end
       end

--- a/spec/active_support_concern_spec.rb
+++ b/spec/active_support_concern_spec.rb
@@ -1,0 +1,26 @@
+require 'helper'
+
+describe 'ActiveSupport::Concern' do
+  describe 'ClassMethods' do
+    module TestConcern
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def concern_test_method
+        end
+      end
+    end
+
+    class NotExtended
+    end
+
+    class Extended
+      include TestConcern
+    end
+
+    it 'should not litter the ClassMethods' do
+      expect(NotExtended).to_not respond_to(:concern_test_method)
+      expect(Extended).to respond_to(:concern_test_method)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #824 
