### PR TITLE
Allow Rails 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :test do
   if ENV['RAILS_VERSION'] == 'edge'
     gem 'activerecord', :github => 'rails/rails'
     gem 'actionmailer', :github => 'rails/rails'
+    gem 'arel', :github => 'rails/arel'
   else
     gem 'activerecord', (ENV['RAILS_VERSION'] || ['>= 3.0', '< 5.0'])
     gem 'actionmailer', (ENV['RAILS_VERSION'] || ['>= 3.0', '< 5.0'])

--- a/delayed_job.gemspec
+++ b/delayed_job.gemspec
@@ -1,5 +1,5 @@
 Gem::Specification.new do |spec|
-  spec.add_dependency 'activesupport', ['>= 3.0', '< 5.0']
+  spec.add_dependency 'activesupport', ['>= 3.0']
   spec.authors        = ['Brandon Keepers', 'Brian Ryckbost', 'Chris Gaffney', 'David Genord II', 'Erik Michaels-Ober', 'Matt Griffin', 'Steve Richert', 'Tobias Lütke']
   spec.description    = 'Delayed_job (or DJ) encapsulates the common pattern of asynchronously executing longer tasks in the background. It is a direct extraction from Shopify where the job table is responsible for a multitude of core tasks.'
   spec.email          = ['brian@collectiveidea.com']


### PR DESCRIPTION
The test suite passes with Rails edge, given the extra edge `arel` dependency that I added to the Gemfile. Please remove the upper limit on `delayed_job`, so bleeding edge folks like me can use it in our Rails 5 (edge) projects.

Thank you for the awesome gem! :heart: 
