### PR TITLE
compatibility hack for jobs created pre rails 4.2

### DIFF
--- a/lib/delayed/psych_ext.rb
+++ b/lib/delayed/psych_ext.rb
@@ -34,6 +34,9 @@ module Delayed
         when /^!ruby\/object/
           result = super
           if defined?(ActiveRecord::Base) && result.is_a?(ActiveRecord::Base)
+            attributes = result.instance_variable_get('@attributes')
+            attributes.define_singleton_method(:fetch_value) do |name| self[name] end unless attributes.respond_to?(:fetch_value)
+
             klass = result.class
             id = result[klass.primary_key]
             begin


### PR DESCRIPTION
Upgrading rails to 4.2 breaks delayed_jobs when its worker is trying to run jobs created in pre 4.2 with the following error:

```
NoMethodError: undefined method `fetch_value' for #<Hash:>
from /path_to_gems/activerecord-4.2.3/lib/active_record/attribute_methods/read.rb:93:in `_read_attribute'
```

This PR tries to make the upgrade process works more smoothly.