### PR TITLE
fix #837 Use delayed_job.log as default logger file.

### DIFF
--- a/lib/delayed/railtie.rb
+++ b/lib/delayed/railtie.rb
@@ -7,12 +7,6 @@ module Delayed
       ActiveSupport.on_load(:action_mailer) do
         ActionMailer::Base.extend(Delayed::DelayMail)
       end
-
-      Delayed::Worker.logger ||= if defined?(Rails)
-        Rails.logger
-      elsif defined?(RAILS_DEFAULT_LOGGER)
-        RAILS_DEFAULT_LOGGER
-      end
     end
 
     rake_tasks do

--- a/lib/delayed/tasks.rb
+++ b/lib/delayed/tasks.rb
@@ -26,10 +26,10 @@ namespace :jobs do
     @worker_options[:sleep_delay] = ENV['SLEEP_DELAY'].to_i if ENV['SLEEP_DELAY']
     @worker_options[:read_ahead] = ENV['READ_AHEAD'].to_i if ENV['READ_AHEAD']
     @worker_options[:log_dir] = if ENV['LOG_DIR']
-                                 ENV['LOG_DIR']
-                                else
-                                 (defined?(Rails.root) ? Rails.root : Dir.pwd) + "/log"
-                                end
+      ENV['LOG_DIR']
+    else
+      (defined?(Rails.root) ? Rails.root : Dir.pwd) + '/log'
+    end
   end
 
   desc "Exit with error status if any jobs older than max_age seconds haven't been attempted yet."

--- a/lib/delayed/tasks.rb
+++ b/lib/delayed/tasks.rb
@@ -6,6 +6,7 @@ namespace :jobs do
 
   desc 'Start a delayed_job worker.'
   task :work => :environment_options do
+    Delayed::Worker.logger = Logger.new(File.join(@worker_options[:log_dir], 'delayed_job.log'))
     Delayed::Worker.new(@worker_options).start
   end
 
@@ -24,6 +25,11 @@ namespace :jobs do
 
     @worker_options[:sleep_delay] = ENV['SLEEP_DELAY'].to_i if ENV['SLEEP_DELAY']
     @worker_options[:read_ahead] = ENV['READ_AHEAD'].to_i if ENV['READ_AHEAD']
+    @worker_options[:log_dir] = if ENV['LOG_DIR']
+                                 ENV['LOG_DIR']
+                                else
+                                 (defined?(Rails.root) ? Rails.root : Dir.pwd) + "/log"
+                                end
   end
 
   desc "Exit with error status if any jobs older than max_age seconds haven't been attempted yet."

--- a/lib/generators/delayed_job/templates/script
+++ b/lib/generators/delayed_job/templates/script
@@ -2,4 +2,6 @@
 
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
 require 'delayed/command'
+
+#Delayed::Worker.logger = Logger.new("your_log_file.log")
 Delayed::Command.new(ARGV).daemonize


### PR DESCRIPTION
I have been using delayed_job for long time. When i upgraded the it to 4.0.6 from 3.0.5, delayed_job logs started mixed with my production logs. So it become difficult to go through delayed_job logs in production log file. But this is solved when i explicitly specify the logger in script. What i thought is, when the user didn't specify the logger, then we can use our default logger(delayed_job.log). Right now we are using Rails logger(Rails.logger) as default one.
