### PR TITLE
Queue priority in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,15 @@ Delayed::Job.enqueue job, :queue => 'tracking'
 handle_asynchronously :tweet_later, :queue => 'tweets'
 ```
 
+You can configure default priorities for named queues:
+
+```ruby
+Delayed::Worker.queue_attributes = [
+  { name: :high_priority, priority: -10 },
+  { name: :low_priority, priority: 10 }
+]
+```
+
 Running Jobs
 ============
 `script/delayed_job` can be used to manage a background process which will

--- a/delayed_job.gemspec
+++ b/delayed_job.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   spec.description    = 'Delayed_job (or DJ) encapsulates the common pattern of asynchronously executing longer tasks in the background. It is a direct extraction from Shopify where the job table is responsible for a multitude of core tasks.'
   spec.email          = ['brian@collectiveidea.com']
   spec.files          = %w[CHANGELOG.md CONTRIBUTING.md LICENSE.md README.md Rakefile delayed_job.gemspec]
-  spec.files += Dir.glob('{contrib,lib,recipes,spec}/**/*')
+  spec.files          += Dir.glob('{contrib,lib,recipes,spec}/**/*') # rubocop:disable SpaceAroundOperators
   spec.homepage       = 'http://github.com/collectiveidea/delayed_job'
   spec.licenses       = ['MIT']
   spec.name           = 'delayed_job'

--- a/lib/delayed/backend/job_preparer.rb
+++ b/lib/delayed/backend/job_preparer.rb
@@ -1,0 +1,51 @@
+module Delayed
+  module Backend
+    class JobPreparer
+      attr_reader :options, :args
+
+      def initialize(*args)
+        @options = args.extract_options!
+        @args = args
+      end
+
+      def prepare
+        set_payload
+        set_queue_name
+        set_priority
+        handle_deprecation
+        options
+      end
+
+    private
+
+      def set_payload
+        options[:payload_object] ||= args.shift
+      end
+
+      def set_queue_name
+        if options[:queue].nil? && options[:payload_object].respond_to?(:queue_name)
+          options[:queue] = options[:payload_object].queue_name
+        else
+          options[:queue] ||= Delayed::Worker.default_queue_name
+        end
+      end
+
+      def set_priority
+        options[:priority] ||= Delayed::Worker.default_priority
+        queue_attributes = Delayed::Worker.queue_attributes.select { |queue| queue[:name].to_s == options[:queue] }
+        options[:priority] = queue_attributes.first[:priority] if queue_attributes.any?
+      end
+
+      def handle_deprecation
+        if args.size > 0
+          warn '[DEPRECATION] Passing multiple arguments to `#enqueue` is deprecated. Pass a hash with :priority and :run_at.'
+          options[:priority] = args.first || options[:priority]
+          options[:run_at]   = args[1]
+        end
+
+        return if options[:payload_object].respond_to?(:perform)
+        raise ArgumentError, 'Cannot enqueue items which do not respond to perform'
+      end
+    end
+  end
+end

--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -314,6 +314,12 @@ shared_examples_for 'a delayed_job backend' do
       end
       expect(described_class.reserve(worker)).to be_nil
     end
+
+    it 'sets job priority based on queue_attributes configuration' do
+      Delayed::Worker.queue_attributes = [{:name => 'job_tracking', :priority => 4}]
+      job = described_class.enqueue :payload_object => NamedQueueJob.new
+      expect(job.priority).to eq(4)
+    end
   end
 
   context 'clear_locks!' do

--- a/lib/delayed/psych_ext.rb
+++ b/lib/delayed/psych_ext.rb
@@ -31,7 +31,7 @@ module Delayed
         return revive(Psych.load_tags[object.tag], object) if Psych.load_tags[object.tag]
 
         case object.tag
-        when /^!ruby\/object/
+        when %r{^!ruby/object}
           result = super
           if defined?(ActiveRecord::Base) && result.is_a?(ActiveRecord::Base)
             klass = result.class
@@ -44,7 +44,7 @@ module Delayed
           else
             result
           end
-        when /^!ruby\/ActiveRecord:(.+)$/
+        when %r{^!ruby/ActiveRecord:(.+)$}
           klass = resolve_class(Regexp.last_match[1])
           payload = Hash[*object.children.map { |c| accept c }]
           id = payload['attributes'][klass.primary_key]
@@ -54,7 +54,7 @@ module Delayed
           rescue ActiveRecord::RecordNotFound => error
             raise Delayed::DeserializationError, "ActiveRecord::RecordNotFound, class: #{klass}, primary key: #{id} (#{error.message})"
           end
-        when /^!ruby\/Mongoid:(.+)$/
+        when %r{^!ruby/Mongoid:(.+)$}
           klass = resolve_class(Regexp.last_match[1])
           payload = Hash[*object.children.map { |c| accept c }]
           id = payload['attributes']['_id']
@@ -63,7 +63,7 @@ module Delayed
           rescue Mongoid::Errors::DocumentNotFound => error
             raise Delayed::DeserializationError, "Mongoid::Errors::DocumentNotFound, class: #{klass}, primary key: #{id} (#{error.message})"
           end
-        when /^!ruby\/DataMapper:(.+)$/
+        when %r{^!ruby/DataMapper:(.+)$}
           klass = resolve_class(Regexp.last_match[1])
           payload = Hash[*object.children.map { |c| accept c }]
           begin

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -15,12 +15,13 @@ module Delayed
     DEFAULT_DEFAULT_PRIORITY = 0
     DEFAULT_DELAY_JOBS       = true
     DEFAULT_QUEUES           = []
+    DEFAULT_QUEUE_ATTRIBUTES = []
     DEFAULT_READ_AHEAD       = 5
 
     cattr_accessor :min_priority, :max_priority, :max_attempts, :max_run_time,
                    :default_priority, :sleep_delay, :logger, :delay_jobs, :queues,
                    :read_ahead, :plugins, :destroy_failed_jobs, :exit_on_complete,
-                   :default_log_level
+                   :default_log_level, :queue_attributes
 
     # Named queue into which jobs are enqueued by default
     cattr_accessor :default_queue_name
@@ -38,6 +39,7 @@ module Delayed
       self.default_priority  = DEFAULT_DEFAULT_PRIORITY
       self.delay_jobs        = DEFAULT_DELAY_JOBS
       self.queues            = DEFAULT_QUEUES
+      self.queue_attributes  = DEFAULT_QUEUE_ATTRIBUTES
       self.read_ahead        = DEFAULT_READ_AHEAD
       @lifecycle             = nil
     end

--- a/lib/delayed_job.rb
+++ b/lib/delayed_job.rb
@@ -14,6 +14,7 @@ require 'delayed/lifecycle'
 require 'delayed/plugin'
 require 'delayed/plugins/clear_locks'
 require 'delayed/backend/base'
+require 'delayed/backend/job_preparer'
 require 'delayed/worker'
 require 'delayed/deserialization_error'
 require 'delayed/railtie' if defined?(Rails::Railtie)


### PR DESCRIPTION
Queue priority is not settable via a config file. This causes complications when you want to set queue priority and leverage ActiveJob in Rails. In order to allow setting queue priority I have created a queue_attributes attribute that falls off the worker. The attribute is then accessed and the priority is set when setting up the job prior to enqueuing.

I have extracted the enqueueing code into it's own class to try and clean things up a little into a `JobPreparer` for a lack of a better name.

Some side notes it may be better to rather use the `queue` attribute on the worker, but I thought this was a good start.

This is my first public PR to someone else's repo. I have read the guidelines ... I am happy if it's rejected, but input on where I can improve in future or how I can change things to provide similar functionality would be much appreciated.

Someone also started a [thread](https://github.com/collectiveidea/delayed_job/issues/782) requesting this functionality.