### PR TITLE
Fix worker crash on serialization error

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -147,6 +147,8 @@ module Delayed
 
       def destroy_failed_jobs?
         payload_object.respond_to?(:destroy_failed_jobs?) ? payload_object.destroy_failed_jobs? : Delayed::Worker.destroy_failed_jobs
+      rescue DeserializationError
+        Delayed::Worker.destroy_failed_jobs
       end
 
       def fail!


### PR DESCRIPTION
This fixes a crash that occurs when queuing a job on an ActiveRecord object that is destroyed before the worker gets a chance to pop the job from the queue.

The root problem is that de-serialization exceptions are handled in `Worker#failed`, which calls `Backend::Base#destroy_failed_jobs?`. The base implementation calls `Backend::Base#payload_object`, which can raise `DeserializationError`.

Here is the stack trace, in all its glory.

```
[Worker(host:pwnage.local pid:22947)] Job Delayed::PerformableMethod (id=4) RUNNING
rake aborted!
Delayed::DeserializationError: ActiveRecord::RecordNotFound, class: Submission, primary key: 783 (Couldn't find Submission with 'id'=783)
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/psych_ext.rb:42:in `rescue in visit_Psych_Nodes_Mapping'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/psych_ext.rb:39:in `visit_Psych_Nodes_Mapping'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/visitor.rb:15:in `visit'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/visitor.rb:5:in `accept'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/to_ruby.rb:31:in `accept'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/to_ruby.rb:321:in `block in revive_hash'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/to_ruby.rb:319:in `each'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/to_ruby.rb:319:in `each_slice'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/to_ruby.rb:319:in `revive_hash'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/to_ruby.rb:357:in `revive'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/to_ruby.rb:207:in `visit_Psych_Nodes_Mapping'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/psych_ext.rb:35:in `visit_Psych_Nodes_Mapping'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/visitor.rb:15:in `visit'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/visitor.rb:5:in `accept'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/to_ruby.rb:31:in `accept'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/to_ruby.rb:295:in `visit_Psych_Nodes_Document'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/visitor.rb:15:in `visit'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/visitor.rb:5:in `accept'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/to_ruby.rb:31:in `accept'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/psych_ext.rb:17:in `load_dj'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/backend/base.rb:91:in `payload_object'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/backend/base.rb:149:in `destroy_failed_jobs?'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:259:in `block in failed'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:61:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:61:in `block in initialize'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:66:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:66:in `execute'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:40:in `run_callbacks'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:252:in `failed'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:231:in `rescue in run'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:222:in `run'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:300:in `block in reserve_and_run_one_job'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:61:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:61:in `block in initialize'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:66:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:66:in `execute'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:40:in `run_callbacks'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:300:in `reserve_and_run_one_job'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:207:in `block in work_off'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:206:in `times'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:206:in `work_off'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:169:in `block (4 levels) in start'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/benchmark.rb:303:in `realtime'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:168:in `block (3 levels) in start'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:61:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:61:in `block in initialize'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:66:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:66:in `execute'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:40:in `run_callbacks'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:167:in `block (2 levels) in start'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:166:in `loop'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:166:in `block in start'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/plugins/clear_locks.rb:7:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/plugins/clear_locks.rb:7:in `block (2 levels) in <class:ClearLocks>'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:79:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:79:in `block (2 levels) in add'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:61:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:61:in `block in initialize'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:79:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:79:in `block in add'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:66:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:66:in `execute'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:40:in `run_callbacks'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:165:in `start'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/tasks.rb:9:in `block (2 levels) in <top (required)>'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/task.rb:240:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/task.rb:240:in `block in execute'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/task.rb:235:in `each'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/task.rb:235:in `execute'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/task.rb:179:in `block in invoke_with_call_chain'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/monitor.rb:211:in `mon_synchronize'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/task.rb:172:in `invoke_with_call_chain'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/task.rb:165:in `invoke'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/application.rb:150:in `invoke_task'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/application.rb:106:in `block (2 levels) in top_level'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/application.rb:106:in `each'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/application.rb:106:in `block in top_level'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/application.rb:115:in `run_with_threads'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/application.rb:100:in `top_level'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/application.rb:78:in `block in run'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/application.rb:176:in `standard_exception_handling'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/application.rb:75:in `run'
/Users/pwnall/.rbenv/versions/2.2.3/bin/rake:33:in `<main>'
ActiveRecord::RecordNotFound: Couldn't find Submission with 'id'=783
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/rails-6ffec3c16c0e/activerecord/lib/active_record/core.rb:165:in `find'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/psych_ext.rb:40:in `visit_Psych_Nodes_Mapping'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/visitor.rb:15:in `visit'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/visitor.rb:5:in `accept'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/to_ruby.rb:31:in `accept'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/to_ruby.rb:321:in `block in revive_hash'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/to_ruby.rb:319:in `each'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/to_ruby.rb:319:in `each_slice'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/to_ruby.rb:319:in `revive_hash'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/to_ruby.rb:357:in `revive'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/to_ruby.rb:207:in `visit_Psych_Nodes_Mapping'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/psych_ext.rb:35:in `visit_Psych_Nodes_Mapping'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/visitor.rb:15:in `visit'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/visitor.rb:5:in `accept'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/to_ruby.rb:31:in `accept'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/to_ruby.rb:295:in `visit_Psych_Nodes_Document'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/visitor.rb:15:in `visit'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/visitor.rb:5:in `accept'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/psych/visitors/to_ruby.rb:31:in `accept'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/psych_ext.rb:17:in `load_dj'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/backend/base.rb:91:in `payload_object'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/backend/base.rb:149:in `destroy_failed_jobs?'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:259:in `block in failed'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:61:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:61:in `block in initialize'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:66:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:66:in `execute'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:40:in `run_callbacks'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:252:in `failed'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:231:in `rescue in run'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:222:in `run'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:300:in `block in reserve_and_run_one_job'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:61:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:61:in `block in initialize'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:66:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:66:in `execute'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:40:in `run_callbacks'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:300:in `reserve_and_run_one_job'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:207:in `block in work_off'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:206:in `times'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:206:in `work_off'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:169:in `block (4 levels) in start'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/benchmark.rb:303:in `realtime'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:168:in `block (3 levels) in start'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:61:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:61:in `block in initialize'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:66:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:66:in `execute'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:40:in `run_callbacks'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:167:in `block (2 levels) in start'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:166:in `loop'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:166:in `block in start'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/plugins/clear_locks.rb:7:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/plugins/clear_locks.rb:7:in `block (2 levels) in <class:ClearLocks>'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:79:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:79:in `block (2 levels) in add'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:61:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:61:in `block in initialize'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:79:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:79:in `block in add'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:66:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:66:in `execute'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/lifecycle.rb:40:in `run_callbacks'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/worker.rb:165:in `start'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/delayed_job-d477cc622e19/lib/delayed/tasks.rb:9:in `block (2 levels) in <top (required)>'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/task.rb:240:in `call'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/task.rb:240:in `block in execute'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/task.rb:235:in `each'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/task.rb:235:in `execute'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/task.rb:179:in `block in invoke_with_call_chain'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/monitor.rb:211:in `mon_synchronize'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/task.rb:172:in `invoke_with_call_chain'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/task.rb:165:in `invoke'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/application.rb:150:in `invoke_task'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/application.rb:106:in `block (2 levels) in top_level'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/application.rb:106:in `each'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/application.rb:106:in `block in top_level'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/application.rb:115:in `run_with_threads'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/application.rb:100:in `top_level'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/application.rb:78:in `block in run'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/application.rb:176:in `standard_exception_handling'
/Users/pwnall/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/application.rb:75:in `run'
/Users/pwnall/.rbenv/versions/2.2.3/bin/rake:33:in `<main>'
```