### PR TITLE
Fix shared specs for back-ends that reload objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Next
+====
+* Fix shared specs for back-ends that reload objects
+
 4.1.0 - 2015-09-22
 ==================
 * Alter `Delayed::Command` to work with or without Rails

--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -542,7 +542,7 @@ shared_examples_for 'a delayed_job backend' do
         it 'marks the job as failed' do
           Delayed::Worker.destroy_failed_jobs = false
           job = described_class.create! :handler => '--- !ruby/object:JobThatDoesNotExist {}'
-          expect(job).to receive(:destroy_failed_jobs?).and_return(false)
+          expect_any_instance_of(described_class).to receive(:destroy_failed_jobs?).and_return(false)
           worker.work_off
           job.reload
           expect(job).to be_failed
@@ -574,7 +574,6 @@ shared_examples_for 'a delayed_job backend' do
       it 're-schedules jobs after failing' do
         worker.work_off
         @job.reload
-        expect(@job.error).to_not be_nil
         expect(@job.last_error).to match(/did not work/)
         expect(@job.last_error).to match(/sample_jobs.rb:\d+:in `perform'/)
         expect(@job.attempts).to eq(1)


### PR DESCRIPTION
This is a fix related to https://github.com/collectiveidea/delayed_job_mongoid/issues/59. The problem is that the mongoid backend does a `find_and_modify` which returns a different object instance when the job is being processed, so you cannot expect the same instance to receive anything as the one you queued.