### PR TITLE
Do not misinterpret log errors as job errors

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -220,18 +220,21 @@ module Delayed
 
     def run(job)
       job_say job, 'RUNNING'
-      runtime = Benchmark.realtime do
-        Timeout.timeout(max_run_time(job).to_i, WorkerTimeout) { job.invoke_job }
-        job.destroy
+      begin
+        runtime = Benchmark.realtime do
+          Timeout.timeout(max_run_time(job).to_i, WorkerTimeout) { job.invoke_job }
+          job.destroy
+        end
+      rescue DeserializationError => error
+        job.error = error
+        failed(job)
+        return false # work failed
+      rescue Exception => error # rubocop:disable RescueException
+        self.class.lifecycle.run_callbacks(:error, self, job) { handle_failed_job(job, error) }
+        return false # work failed
       end
       job_say job, format('COMPLETED after %.4f', runtime)
-      return true # did work
-    rescue DeserializationError => error
-      job.error = error
-      failed(job)
-    rescue Exception => error # rubocop:disable RescueException
-      self.class.lifecycle.run_callbacks(:error, self, job) { handle_failed_job(job, error) }
-      return false # work failed
+      true # did work
     end
 
     # Reschedule the job in the future (when a job fails).

--- a/spec/delayed/backend/test.rb
+++ b/spec/delayed/backend/test.rb
@@ -94,6 +94,7 @@ module Delayed
 
         def destroy
           self.class.all.delete(self)
+          freeze
         end
 
         def save


### PR DESCRIPTION
Fix #850

In the event that an exception occurs while the logger is logging the successful running of the job, DelayedJob will assume that the exception occurred during the job invocation, and then proceed to handle the job as though it had failed. If the job succeeded, it's likely to be destroyed and frozen, and will raise an unhandled exception about not being able to modify a frozen object.

This exception is confusing. I propose that DelayedJob instead doesn't rescue log-related failures. That way, when something goes wrong the logs after the job succeeds (which is a very specific sequence of events, I admit, but does happen sometimes) the correct exception reaches the developer instead of a confusing one about trying to modify a frozen job.

DJ could rescue that exception, too, but I'm not sure it's DJ's responsibility to suppress log failure