### PR TITLE
Only perform error callback when job really failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Next
+====
+
+* Fix worker crashing when job succeeds but logger fails
+
 4.1.1 - 2015-09-24
 ==================
 * Fix shared specs for back-ends that reload objects

--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -550,6 +550,26 @@ shared_examples_for 'a delayed_job backend' do
       end
     end
 
+    context 'when the logger fails' do
+      before do
+        logger = double('logger')
+        expect(logger).to receive(:info).with(/RUNNING/)
+        expect(logger).to receive(:info).with(/COMPLETED/).
+          and_raise(RuntimeError, 'Something went wrong with logging')
+
+        @old_logger = Delayed::Worker.logger
+        Delayed::Worker.logger = logger
+
+        @job = Delayed::Job.enqueue(SimpleJob.new)
+      end
+
+      after { Delayed::Worker.logger = @old_logger }
+
+      it 'should not fail' do
+        expect(worker.run(@job)).to be true
+      end
+    end
+
     describe 'failed jobs' do
       before do
         @job = Delayed::Job.enqueue(ErrorJob.new, :run_at => described_class.db_time_now - 1)

--- a/spec/delayed/backend/test.rb
+++ b/spec/delayed/backend/test.rb
@@ -94,6 +94,11 @@ module Delayed
 
         def destroy
           self.class.all.delete(self)
+          freeze
+        end
+
+        def persisted?
+          self.class.all.include?(self)
         end
 
         def save


### PR DESCRIPTION
This fixes #850, which describes a specific scenario where DJ workers can crash when the logger fails to log that a job was processed successfully.

The one downside of this fix is that some messages won't be logged, and the developer won't know about it. This is why I initially implemented PR #852 to not rescue those logging exceptions, but it sounds like keeping the workers alive is more important than knowing if a log failed. That kind of makes sense to me.
