### PR TITLE
Fixe for Syck YAML loading error: "method 'load_dj'"

### DIFF
--- a/lib/delayed/syck_ext.rb
+++ b/lib/delayed/syck_ext.rb
@@ -34,7 +34,7 @@ class Struct
 end
 
 module YAML
-  def load_dj(yaml)
+  def self.load_dj(yaml)
     # See https://github.com/dtao/safe_yaml
     # When the method is there, we need to load our YAML like this...
     respond_to?(:unsafe_load) ? load(yaml, :safe => false) : load(yaml)


### PR DESCRIPTION
Fixes error when loading job with newer Ruby and Syck is used as YAML engine (tenderlove/syck gem):

"Job failed to load: undefined method `load_dj' for Syck:Module"

Fixes #786