### PR TITLE
Don't output time in logs

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -274,7 +274,7 @@ module Delayed
       unless level.is_a?(String)
         level = Logger::Severity.constants.detect { |i| Logger::Severity.const_get(i) == level }.to_s.downcase
       end
-      logger.send(level, "#{Time.now.strftime('%FT%T%z')}: #{text}")
+      logger.send(level, text)
     end
 
     def max_attempts(job)

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -113,11 +113,8 @@ describe Delayed::Worker do
       @worker = Delayed::Worker.new
       @worker.name = 'ExampleJob'
       @worker.logger = double('job')
-      time = Time.now
-      allow(Time).to receive(:now).and_return(time)
       @text = 'Job executed'
       @worker_name = '[Worker(ExampleJob)]'
-      @expected_time = time.strftime('%FT%T%z')
     end
 
     after(:each) do
@@ -127,13 +124,13 @@ describe Delayed::Worker do
     shared_examples_for 'a worker which logs on the correct severity' do |severity|
       it "logs a message on the #{severity[:level].upcase} level given a string" do
         expect(@worker.logger).to receive(:send).
-          with(severity[:level], "#{@expected_time}: #{@worker_name} #{@text}")
+          with(severity[:level], "#{@worker_name} #{@text}")
         @worker.say(@text, severity[:level])
       end
 
       it "logs a message on the #{severity[:level].upcase} level given a fixnum" do
         expect(@worker.logger).to receive(:send).
-          with(severity[:level], "#{@expected_time}: #{@worker_name} #{@text}")
+          with(severity[:level], "#{@worker_name} #{@text}")
         @worker.say(@text, severity[:index])
       end
     end
@@ -150,7 +147,7 @@ describe Delayed::Worker do
 
     it 'logs a message on the default log\'s level' do
       expect(@worker.logger).to receive(:send).
-        with('info', "#{@expected_time}: #{@worker_name} #{@text}")
+        with('info', "#{@worker_name} #{@text}")
       @worker.say(@text, Delayed::Worker.default_log_level)
     end
   end


### PR DESCRIPTION
Most loggers will deal with appending time to each log line so there is
not point starting each log line with the time. Also there may be
loggers that don't want to have time in the output.