### PR TITLE
Add sleep_delay description

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,8 @@ By default all jobs will be queued without a named queue. A default named queue 
 
 It is possible to disable delayed jobs for testing purposes. Set `Delayed::Worker.delay_jobs = false` to execute all jobs realtime.
 
+If no jobs are found, the worker sleeps for the amount of time specified by the sleep delay option. Set `Delayed::Worker.sleep_delay = 60` for a 60 second sleep time.
+
 Or `Delayed::Worker.delay_jobs` can be a Proc that decides whether to execute jobs inline on a per-job basis:
 
 ```ruby


### PR DESCRIPTION
In the README, all the options are explained other than `sleep_delay` ... so I search the code to understand what it does and figured I'd add it in.