### PR TITLE
Add failing test for Ruby 2.3 + Mongoid

### DIFF
--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -521,6 +521,13 @@ shared_examples_for 'a delayed_job backend' do
         expect { job.reload.payload_object }.to raise_error(Delayed::DeserializationError)
       end
     end
+
+    context 'when db object is an instance variable of another object' do
+      it 'can work!' do
+        job = Delayed::Job.create :payload_object => StoryWrapperJob.new
+        expect(job.reload.payload_object).to be_a StoryWrapperJob
+      end
+    end
   end
 
   describe 'worker integration' do

--- a/spec/sample_jobs.rb
+++ b/spec/sample_jobs.rb
@@ -109,3 +109,16 @@ class EnqueueJobMod < SimpleJob
     job.run_at = 20.minutes.from_now
   end
 end
+
+class StoryWrapperJob < SimpleJob
+  def initialize
+    # sample object referenced twice should get compressed during yaml serialization to use aliases, which should then be deserializable.
+    @story = Story.create!(text: "My great story")
+    @story_again = @story
+  end
+
+  def perform
+    @story.tell
+    super
+  end
+end

--- a/spec/sample_jobs.rb
+++ b/spec/sample_jobs.rb
@@ -113,7 +113,7 @@ end
 class StoryWrapperJob < SimpleJob
   def initialize
     # sample object referenced twice should get compressed during yaml serialization to use aliases, which should then be deserializable.
-    @story = Story.create!(text: "My great story")
+    @story = Story.create!(:text => 'My great story')
     @story_again = @story
   end
 


### PR DESCRIPTION
I'm trying to upgrade to Ruby 2.3, and I'm observing some failing tests,
which I've tried to reproduce here for you. This test only fails for
delayed_job_mongoid, not delayed_job_active_record. So the build for
this repo will be green. But I'll make a PR against the other one to
demonstrate the failure.

The issue, as I understand it, is this: when Ruby serializes an object
to yaml and there are multiple references to the same value, it will use
"aliases" to avoid duplicating the data and save space. That's sweet!
But it seems like DJ can't deserialize those aliases when they're
referring to instances of mongoid models.
