### PR TITLE
allow specification of max run time per worker, from the command line

### DIFF
--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -76,6 +76,9 @@ module Delayed
         opt.on('--exit-on-complete', 'Exit when no more jobs are available to run. This will exit if all jobs are scheduled to run in the future.') do
           @options[:exit_on_complete] = true
         end
+        opt.on('--max-run-time N', 'Specify maximum run time of jobs (in seconds). Overrides Delayed::Worker.max_run_time') do |n|
+          @options[:max_run_time] = n.to_i
+        end
       end
       @args = opts.parse!(args)
     end

--- a/lib/delayed/tasks.rb
+++ b/lib/delayed/tasks.rb
@@ -24,6 +24,7 @@ namespace :jobs do
 
     @worker_options[:sleep_delay] = ENV['SLEEP_DELAY'].to_i if ENV['SLEEP_DELAY']
     @worker_options[:read_ahead] = ENV['READ_AHEAD'].to_i if ENV['READ_AHEAD']
+    @worker_options[:max_run_time] = ENV['MAX_RUN_TIME'].to_i if ENV['MAX_RUN_TIME']
   end
 
   desc "Exit with error status if any jobs older than max_age seconds haven't been attempted yet."

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -126,7 +126,7 @@ module Delayed
       @quiet = options.key?(:quiet) ? options[:quiet] : true
       @failed_reserve_count = 0
 
-      [:min_priority, :max_priority, :sleep_delay, :read_ahead, :queues, :exit_on_complete].each do |option|
+      [:min_priority, :max_priority, :sleep_delay, :read_ahead, :queues, :exit_on_complete, :max_run_time].each do |option|
         self.class.send("#{option}=", options[option]) if options.key?(option)
       end
 


### PR DESCRIPTION
This is a change to allow specifying the per-worker max run time via the command line, either via MAX_RUN_TIME env variable, or --max-run-time option to the script.

There's no current way that I can see to set this value, other than globally via Delayed::Worker.max_run_time. It's sometimes essential for us to be able to spin up a single worker with a different value.