### PR TITLE
max parallel execution configurable for each queue

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -15,12 +15,14 @@ module Delayed
     DEFAULT_DEFAULT_PRIORITY = 0
     DEFAULT_DELAY_JOBS       = true
     DEFAULT_QUEUES           = []
+    DEFAULT_DEFAULT_MAX_WORKERS_BY_QUEUE = nil # By default, there is no limit of concurrent workers running job from the same queue.
+    DEFAULT_MAX_WORKERS_BY_QUEUE = {}
     DEFAULT_READ_AHEAD       = 5
 
     cattr_accessor :min_priority, :max_priority, :max_attempts, :max_run_time,
                    :default_priority, :sleep_delay, :logger, :delay_jobs, :queues,
                    :read_ahead, :plugins, :destroy_failed_jobs, :exit_on_complete,
-                   :default_log_level
+                   :default_log_level, :default_max_workers_by_queue, :max_workers_by_queue
 
     # Named queue into which jobs are enqueued by default
     cattr_accessor :default_queue_name
@@ -38,6 +40,8 @@ module Delayed
       self.default_priority  = DEFAULT_DEFAULT_PRIORITY
       self.delay_jobs        = DEFAULT_DELAY_JOBS
       self.queues            = DEFAULT_QUEUES
+      self.default_max_workers_by_queue = DEFAULT_DEFAULT_MAX_WORKERS_BY_QUEUE
+      self.max_workers_by_queue = DEFAULT_MAX_WORKERS_BY_QUEUE
       self.read_ahead        = DEFAULT_READ_AHEAD
       @lifecycle             = nil
     end


### PR DESCRIPTION
This change with another on delayed_job_active_record permits to configure a limit of concurrent execution of a queue.
Follows an example of configuration in the config/initializers/delayed_job.rb where "import" and "export" are queue names.
`Delayed::Worker.default_max_workers_by_queue = 3`
`Delayed::Worker.max_workers_by_queue = {"import" => 1, "export" => 2}`

This configuration permits to optimize the use of the workers, and in the same time to control that one queue don't take all available workers or that two jobs from one specific queue could not be execute in the same time.
