### PR TITLE
Coerce object.tag to string in Psych extension (v3)

### DIFF
--- a/lib/delayed/psych_ext.rb
+++ b/lib/delayed/psych_ext.rb
@@ -93,7 +93,7 @@ module Psych
       def visit_Psych_Nodes_Mapping_with_class(object)
         return revive(Psych.load_tags[object.tag], object) if Psych.load_tags[object.tag]
 
-        case object.tag
+        case object.tag.to_s
         when /^!ruby\/ActiveRecord:(.+)$/
           klass = resolve_class($1)
           payload = Hash[*object.children.map { |c| accept c }]


### PR DESCRIPTION
I'm seeing a ton of `NilClass#method_missing` errors on the first boot of a Rails 3 app using DelayedJob 3.0.5 and can't upgrade to v4. Can we get this into a patch of 3.0, maybe 3.0.6?
