### PR TITLE
Don't mutate the options hash

### DIFF
--- a/lib/delayed/backend/job_preparer.rb
+++ b/lib/delayed/backend/job_preparer.rb
@@ -4,7 +4,7 @@ module Delayed
       attr_reader :options, :args
 
       def initialize(*args)
-        @options = args.extract_options!
+        @options = args.extract_options!.dup
         @args = args
       end
 

--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -113,6 +113,13 @@ shared_examples_for 'a delayed_job backend' do
         job = described_class.enqueue M::ModuleJob.new
         expect { job.invoke_job }.to change { M::ModuleJob.runs }.from(0).to(1)
       end
+
+      it 'does not mutate the options hash' do
+        options = { priority: 1}
+        job = described_class.enqueue SimpleJob.new, options
+        expect(options).to eq({ priority: 1 })
+      end
+
     end
 
     context 'with delay_jobs = false' do


### PR DESCRIPTION
**Problem:** `#enqueue` method mutates the options hash which includes priority, queue name, etc. This causes problems, if the same hash is used to create another job. In general, mutating method arguments is unexpected and a bad practise (might be a matter of taste but at least in my opinion it is a bit bad).

Because of this, creating a second job with the same options fails and throws an error `ActiveRecord::StatementInvalid: SQLite3::ConstraintException: NOT NULL constraint failed`

In my application when I first discovered this issue, my DB schema was a bit outdated and it allowed NULL values for priority. The job was successfully written to the database, but it contained the parameters that belonged to the first job (that is, `id: 1` instead of `id: 2`, see the steps to reproduce).

**Solution:** Clone the hash before mutating it

**Steps to reproduce:**

``` bash
> rails --version
# Rails 4.2.5.1
> rails new dont-mutate
> cd dont-mutate
> echo "gem 'delayed_job', :git => 'https://github.com/collectiveidea/delayed_job.git'" >> Gemfile
> echo "gem 'delayed_job_active_record'" >> Gemfile
> bundle install
> rails generate delayed_job:active_record
> rake db:migrate
> mkdir app/utils/
> touch app/utils/runner.rb
```

``` ruby
# app/utils/runner.rb
class Runner
  Job = Struct.new(:id) do |id|
    def perform
      # do something with the id
    end
  end

  DEFAULT_OPTIONS = {
    priority: 1,
    queue: "important"
  }

  def run(id:)
    Delayed::Job.enqueue(Job.new(id), DEFAULT_OPTIONS)
  end
end
```

``` bash
> rails console
console> require_relative './app/utils/runner'
console> @runner = Runner.new
console> @runner.run(id: 1)

# Expected: New job created with id: 1, priority: 1, queue: "important"
# Actual: New job created with id: 1, priority: 1, queue: "important"

# Try again:
console> @runner.run(id: 2)

# Expected: New job created with id: 2, priority: 1, queue: "important"
# Actual:

[DEPRECATION] Passing multiple arguments to `#enqueue` is deprecated. Pass a hash with :priority and :run_at.
   (0.1ms)  begin transaction
  SQL (1.2ms)  INSERT INTO "delayed_jobs" ("priority", "queue", "handler", "run_at", "created_at", "updated_at") VALUES (?, ?, ?, ?, ?, ?)  [["priority", nil], ["queue", "important"], ["handler", "--- !ruby/struct:Runner::Job\nid: 1\n"], ["run_at", "2016-02-06 11:11:00.593972"], ["created_at", "2016-02-06 11:11:00.594317"], ["updated_at", "2016-02-06 11:11:00.594317"]]
   (0.1ms)  rollback transaction
ActiveRecord::StatementInvalid: SQLite3::ConstraintException: NOT NULL constraint failed: delayed_jobs.priority: INSERT INTO "delayed_jobs" ("priority", "queue", "handler", "run_at", "created_at", "updated_at") VALUES (?, ?, ?, ?, ?, ?)
```
