### PR TITLE
Do not log job removed when destroy_failed_jobs? is false

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -244,7 +244,7 @@ module Delayed
         job.unlock
         job.save!
       else
-        job_say job, "REMOVED permanently because of #{job.attempts} consecutive failures", 'error'
+        job_say(job, "REMOVED permanently because of #{job.attempts} consecutive failures", 'error') if job.destroy_failed_jobs?
         failed(job)
       end
     end


### PR DESCRIPTION
The worker incorrectly logs that the job is removed when destroy_failed_jobs? is false