### PR TITLE
exclude_queues and eval_queues

### DIFF
--- a/delayed_job.gemspec
+++ b/delayed_job.gemspec
@@ -1,3 +1,4 @@
+# encoding: utf-8
 Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', ['>= 3.0', '< 5.0']
   spec.authors        = ['Brandon Keepers', 'Brian Ryckbost', 'Chris Gaffney', 'David Genord II', 'Erik Michaels-Ober', 'Matt Griffin', 'Steve Richert', 'Tobias Lütke']

--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -391,19 +391,40 @@ shared_examples_for 'a delayed_job backend' do
     end
 
     context 'when worker does not have queue set' do
-      before(:each) do
-        worker.queues = []
+      context 'but has exclude_queues' do 
+        before(:each) do
+          worker.queues = []
+          worker.exclude_queues = ['two']
+        end
+
+        it 'works off all jobs, except excluded' do
+          expect(SimpleJob.runs).to eq(0)
+
+          create_job(:queue => 'one')
+          create_job(:queue => 'two')
+          create_job
+          worker.work_off
+
+          expect(SimpleJob.runs).to eq(2)
+        end
       end
 
-      it 'works off all jobs' do
-        expect(SimpleJob.runs).to eq(0)
+      context 'and also no exclude_queues' do
+        before(:each) do
+          worker.queues = []
+          worker.exclude_queues = []
+        end
 
-        create_job(:queue => 'one')
-        create_job(:queue => 'two')
-        create_job
-        worker.work_off
+        it 'works off all jobs' do
+          expect(SimpleJob.runs).to eq(0)
 
-        expect(SimpleJob.runs).to eq(3)
+          create_job(:queue => 'one')
+          create_job(:queue => 'two')
+          create_job
+          worker.work_off
+
+          expect(SimpleJob.runs).to eq(3)
+        end
       end
     end
   end

--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -70,6 +70,14 @@ module Delayed
         opt.on('--queue=queue', 'Specify which queue DJ must look up for jobs') do |queue|
           @options[:queues] = queue.split(',')
         end
+        opt.on('--exclude_queues=queues', 'Specify which queues DJ must NOT look up for jobs') do |exclude_queues|
+          @options[:exlude_queues] = exclude_queues.split(',')
+        end
+        opt.on('--eval_queues=evalstring', "Specify a string, which will be eval'ed to where() while lookup. E.g. \"['created_at < ',2.days.ago]\"") do |eval_queues|
+          # this will fail (throwing an exception), if option eval_queues is not a valid argument to eval or where
+          Delayed::Job.where(eval(eval_queues)).any?
+          @options[:eval_queues] = eval_queues
+        end
         opt.on('--pool=queue1[,queue2][:worker_count]', 'Specify queues and number of workers for a worker pool') do |pool|
           parse_worker_pool(pool)
         end

--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -71,7 +71,7 @@ module Delayed
           @options[:queues] = queue.split(',')
         end
         opt.on('--exclude_queues=queues', 'Specify which queues DJ must NOT look up for jobs') do |exclude_queues|
-          @options[:exlude_queues] = exclude_queues.split(',')
+          @options[:exclude_queues] = exclude_queues.split(',')
         end
         opt.on('--eval_queues=evalstring', "Specify a string, which will be eval'ed to where() while lookup. E.g. \"['created_at < ',2.days.ago]\"") do |eval_queues|
           # this will fail (throwing an exception), if option eval_queues is not a valid argument to eval or where

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -15,6 +15,8 @@ module Delayed
     DEFAULT_DEFAULT_PRIORITY = 0
     DEFAULT_DELAY_JOBS       = true
     DEFAULT_QUEUES           = []
+    DEFAULT_EXCLUDE_QUEUES   = []
+    DEFAULT_EVAL_QUEUES      = nil
     DEFAULT_READ_AHEAD       = 5
 
     cattr_accessor :min_priority, :max_priority, :max_attempts, :max_run_time,
@@ -24,6 +26,10 @@ module Delayed
 
     # Named queue into which jobs are enqueued by default
     cattr_accessor :default_queue_name
+
+    # Named queues to exclude
+    cattr_accessor :exclude_queues, :eval_queues
+
 
     cattr_reader :backend
 
@@ -38,6 +44,8 @@ module Delayed
       self.default_priority  = DEFAULT_DEFAULT_PRIORITY
       self.delay_jobs        = DEFAULT_DELAY_JOBS
       self.queues            = DEFAULT_QUEUES
+      self.exclude_queues    = DEFAULT_EXCLUDE_QUEUES
+      self.eval_queues       = DEFAULT_EVAL_QUEUES
       self.read_ahead        = DEFAULT_READ_AHEAD
       @lifecycle             = nil
     end
@@ -125,7 +133,7 @@ module Delayed
       @quiet = options.key?(:quiet) ? options[:quiet] : true
       @failed_reserve_count = 0
 
-      [:min_priority, :max_priority, :sleep_delay, :read_ahead, :queues, :exit_on_complete].each do |option|
+      [:min_priority, :max_priority, :sleep_delay, :read_ahead, :queues, :exit_on_complete, :exclude_queues, :eval_queues].each do |option|
         self.class.send("#{option}=", options[option]) if options.key?(option)
       end
 

--- a/spec/delayed/backend/test.rb
+++ b/spec/delayed/backend/test.rb
@@ -67,6 +67,7 @@ module Delayed
           jobs.select! { |j| j.priority <= Worker.max_priority } if Worker.max_priority
           jobs.select! { |j| j.priority >= Worker.min_priority } if Worker.min_priority
           jobs.select! { |j| Worker.queues.include?(j.queue) } if Worker.queues.any?
+          jobs.select! { |j| !Worker.exclude_queues.include?(j.queue) } if Worker.exclude_queues.any?
           jobs.sort_by! { |j| [j.priority, j.run_at] }[0..limit - 1]
         end
 


### PR DESCRIPTION
We wanted worker to explicitly exclude queues. 
Additional, with the eval_queues option, one can specify a string, which will be eval'ed to where() while lookup. E.g. "['created_at < ?', 2.days.ago]"