### PR TITLE
force utf-8 encoding to account for umlaut in Tobias Lütke_s name

### DIFF
--- a/delayed_job.gemspec
+++ b/delayed_job.gemspec
@@ -1,3 +1,5 @@
+#encoding: UTF-8
+
 Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', ['>= 3.0', '< 5.1']
   spec.authors        = ['Brandon Keepers', 'Brian Ryckbost', 'Chris Gaffney', 'David Genord II', 'Erik Michaels-Ober', 'Matt Griffin', 'Steve Richert', 'Tobias Lütke']


### PR DESCRIPTION
Per [this issue](https://github.com/fastlane/fastlane/issues/227), [KrauseFx](https://github.com/KrauseFx) suggested a great work-around, however the root of the issue is in the [delayed_job.gemspec](https://github.com/collectiveidea/delayed_job/blob/master/delayed_job.gemspec#L3)

![screen shot 2016-04-08 at 10 07 22 am](https://cloud.githubusercontent.com/assets/6538292/14386268/10055a0c-fd72-11e5-832f-301e701fb243.png)

Author Tobias Lütke's name contains a UTF-8 character that poses no problems when delayed_job is bundled into a project as a gem, but can break a build with gnarly encoding errors when included directly from github , i.e. 

`gem 'delayed_job', github: 'collectiveidea/delayed_job'` in your Gemfile

forcing UTF-8 encoding by adding `#encoding: UTF-8` to the top of the gemspec file solves the issue.