### PR TITLE
Allow daemon-options to be passed through

### DIFF
--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -77,7 +77,7 @@ module Delayed
         opt.on('--exit-on-complete', 'Exit when no more jobs are available to run. This will exit if all jobs are scheduled to run in the future.') do
           @options[:exit_on_complete] = true
         end
-        opt.on('--daemon-options a, b, c', Array, 'options to be passed through to daemon gem') do |daemon_options|
+        opt.on('--daemon-options a, b, c', Array, 'options to be passed through to daemons gem') do |daemon_options|
           @daemon_options = daemon_options
         end
       end


### PR DESCRIPTION
hey @albus522,

here I have a more flexible update of https://github.com/collectiveidea/delayed_job/pull/459. the idea here is to allow users to pass options through to the daemons gem. i'm specifically interested in telling daemons not to forcefully kill my workers after their timeout.

your last question on that thread was whether the option they were adding in that PR was tied to a certain minimum version of the daemons gem. [it is](https://github.com/thuehlinger/daemons/commit/c6f477b7eb08b6931e3d94cf066df0bc64a19393#diff-d50ae403cb49a205bdf789f377f5cfe6R13), but that minimum version of `daemons` (1.1.0) was released in 2010 https://rubygems.org/gems/daemons/versions/1.2.3.

this update also allows you to pass whatever options you want through so it shouldnt even matter what version of daemons you are using, so long as your `daemon-options` are geared towards the right version.

this works like this:

```
rob@rob-ubuntu ~/workspace/lumos_data_warehouse (test_of_delayed_job) => RAILS_ENV=development bundle exec script/delayed_job --queues=restart_test -n 1 --daemon-options='--no_wait' -p dj_worker start
delayed_job: process with pid 8879 started.
rob@rob-ubuntu ~/workspace/lumos_data_warehouse (test_of_delayed_job) => RAILS_ENV=development bundle exec script/delayed_job stop --daemon-options='--no_wait'
rob@rob-ubuntu ~/workspace/lumos_data_warehouse (test_of_delayed_job) => RAILS_ENV=development bundle exec script/delayed_job status
delayed_job: running [pid 8879]
rob@rob-ubuntu ~/workspace/lumos_data_warehouse (test_of_delayed_job) => RAILS_ENV=development bundle exec script/delayed_job status
delayed_job: running [pid 8879]
rob@rob-ubuntu ~/workspace/lumos_data_warehouse (test_of_delayed_job) => RAILS_ENV=development bundle exec script/delayed_job status
delayed_job: no instances running
```

please let me know if you have any questions or concerns.
