### PR TITLE
Adding the queue name to the log output

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -268,7 +268,7 @@ module Delayed
     end
 
     def job_say(job, text, level = default_log_level)
-      text = "Job #{job.name} (id=#{job.id}) #{text}"
+      text = "Job #{job.name} (id=#{job.id})#{say_queue(job.queue)} #{text}"
       say text, level
     end
 
@@ -292,6 +292,10 @@ module Delayed
     end
 
   protected
+
+    def say_queue(queue)
+      " (queue=#{queue})" if queue
+    end
 
     def handle_failed_job(job, error)
       job.error = error

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -24,12 +24,20 @@ describe Delayed::Worker do
   describe 'job_say' do
     before do
       @worker = Delayed::Worker.new
-      @job = double('job', :id => 123, :name => 'ExampleJob')
+      @job = double('job', :id => 123, :name => 'ExampleJob', :queue => nil)
     end
 
     it 'logs with job name and id' do
+      expect(@job).to receive(:queue)
       expect(@worker).to receive(:say).
         with('Job ExampleJob (id=123) message', Delayed::Worker.default_log_level)
+      @worker.job_say(@job, 'message')
+    end
+
+    it 'logs with job name, queue and id' do
+      expect(@job).to receive(:queue).and_return('test')
+      expect(@worker).to receive(:say).
+        with('Job ExampleJob (id=123) (queue=test) message', Delayed::Worker.default_log_level)
       @worker.job_say(@job, 'message')
     end
 


### PR DESCRIPTION
This was helpful for us to know that we had a queues, pools and workers setup correctly. We were running into some issues where the workers did not have a queue specified and were picking up jobs from a queue we did not what them to run.
