### PR TITLE
fix readme bundle exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Run `bundle install` to install the backend and delayed_job gems.
 The Active Record backend requires a jobs table. You can create that table by
 running the following command:
 
-    rails generate delayed_job:active_record
-    rake db:migrate
+    bundle exec rails generate delayed_job:active_record
+    bundle exec rake db:migrate
 
 For Rails 4.2, see [below](#rails-42)
 
@@ -94,8 +94,8 @@ Delayed Job 3.0.0 introduces a new column to the delayed_jobs table.
 
 If you're upgrading from Delayed Job 2.x, run the upgrade generator to create a migration to add the column.
 
-    rails generate delayed_job:upgrade
-    rake db:migrate
+    bundle exec rails generate delayed_job:upgrade
+    bundle exec rake db:migrate
 
 Queuing Jobs
 ============


### PR DESCRIPTION
In the README.md, use bundle install.
And gerenate database command like this.

```
rails generate delayed_job:active_record
rake db:migrate
```

But, this command not use bundler's rails and rake.
So, when rails&rake in global and in Gemfile.lock are different version, we got error like this.

```
% rake db:migrate
rake aborted!
Gem::LoadError: You have already activated rake 10.4.2, but your Gemfile requires rake 11.1.2. Prepending `bundle exec` to your command may solve this.
/workspace/delayed_job_test/config/boot.rb:3:in `<top (required)>'
/workspace/delayed_job_test/config/application.rb:1:in `<top (required)>'
/workspace/delayed_job_test/Rakefile:4:in `<top (required)>'
LoadError: cannot load such file -- bundler/setup
/workspace/delayed_job_test/config/boot.rb:3:in `<top (required)>'
/workspace/delayed_job_test/config/application.rb:1:in `<top (required)>'
/workspace/delayed_job_test/Rakefile:4:in `<top (required)>'
(See full trace by running task with --trace)
```

So we should use `bundle exec` when use rails and rake.
(This gem support Rails 3.0+ and bin/rails, bin/rake aren't exist in rails 3.x, so we need use `bundle exec`)

Same problem in this line.

```
rails generate delayed_job:upgrade
rake db:migrate
```
