### PR TITLE
delete rails 2 comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ multitude of core tasks. Amongst those tasks are:
 
 Installation
 ============
-delayed_job 3.0.0 only supports Rails 3.0+. See the [2.0
-branch](https://github.com/collectiveidea/delayed_job/tree/v2.0) for Rails 2.
+delayed_job 3.0.0 only supports Rails 3.0+.
 
 delayed_job supports multiple backends for storing the job queue. [See the wiki
 for other backends](https://github.com/collectiveidea/delayed_job/wiki/Backends).


### PR DESCRIPTION
The rails 2.x is very old, and it's no longer supported.
http://guides.rubyonrails.org/maintenance_policy.html

So I think this link is not necessary.
