### PR TITLE
Small warning cleanup

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -135,6 +135,10 @@ module Delayed
         self.class.send("#{option}=", options[option]) if options.key?(option)
       end
 
+      @exit ||= nil
+      @name_prefix ||= ''
+      @name ||= nil
+
       # Reset lifecycle on the offhand chance that something lazily
       # triggered its creation before all plugins had been registered.
       self.class.setup_lifecycle


### PR DESCRIPTION
- Let people specify `name` and `name_prefix` in options
- Change the `name` function to not fire warnings that `name` was not initialized.
- Preinitialize `@exit` to nil so it doesn't warn as well.

This is to fix the following warnings:

```
~/.rvm/gems/ruby-2.3.0/bundler/gems/delayed_job-20d40edf12a8/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
~/.rvm/gems/ruby-2.3.0/bundler/gems/delayed_job-20d40edf12a8/lib/delayed/worker.rb:151: warning: instance variable @name_prefix not initialized
~/.rvm/gems/ruby-2.3.0/bundler/gems/delayed_job-20d40edf12a8/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
~/.rvm/gems/ruby-2.3.0/bundler/gems/delayed_job-20d40edf12a8/lib/delayed/worker.rb:151: warning: instance variable @name_prefix not initialized
~/.rvm/gems/ruby-2.3.0/bundler/gems/delayed_job-20d40edf12a8/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
~/.rvm/gems/ruby-2.3.0/bundler/gems/delayed_job-20d40edf12a8/lib/delayed/worker.rb:151: warning: instance variable @name_prefix not initialized
~/.rvm/gems/ruby-2.3.0/bundler/gems/delayed_job-20d40edf12a8/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
~/.rvm/gems/ruby-2.3.0/bundler/gems/delayed_job-20d40edf12a8/lib/delayed/worker.rb:151: warning: instance variable @name_prefix not initialized
~/.rvm/gems/ruby-2.3.0/bundler/gems/delayed_job-20d40edf12a8/lib/delayed/worker.rb:206: warning: instance variable @exit not initialized
```
