### PR TITLE
don't include ClassMethods with MessageSending

### DIFF
--- a/lib/delayed_job.rb
+++ b/lib/delayed_job.rb
@@ -19,4 +19,4 @@ require 'delayed/deserialization_error'
 require 'delayed/railtie' if defined?(Rails::Railtie)
 
 Object.send(:include, Delayed::MessageSending)
-Module.send(:include, Delayed::MessageSending::ClassMethods)
+Module.send(:include, Delayed::ClassMethods)

--- a/spec/message_sending_spec.rb
+++ b/spec/message_sending_spec.rb
@@ -1,6 +1,11 @@
 require 'helper'
 
 describe Delayed::MessageSending do
+  it 'does not include ClassMethods along with MessageSending' do
+    expect { ClassMethods }.to raise_error(NameError)
+    expect(defined?(String::ClassMethods)).to eq(nil)
+  end
+
   describe 'handle_asynchronously' do
     class Story
       def tell!(_arg); end


### PR DESCRIPTION
moves `Delayed::ClassMethods` out of `Delayed::MessageSending` because
`lib/delayed_job.rb` includes `Delayed::MessageSending` into `Object`, and
that has the side-effect of defining `ClassMethods` in _every_ `Object`

---

I discovered this issue when finding out that rails wouldn't autoload a file named `class_methods.rb` in a different project. This bug defines `ClassMethods` for _every_ `Object`, which prevents rails' autoloader from triggering and `require`ing respectively named files.
