### PR TITLE
Remove max_run_time support

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,22 +310,6 @@ NewsletterJob = Struct.new(:text, :emails) do
 end
 ```
 
-To set a per-job max run time that overrides the Delayed::Worker.max_run_time you can define a max_run_time method on the job
-
-NOTE: this can ONLY be used to set a max_run_time that is lower than Delayed::Worker.max_run_time. Otherwise the lock on the job would expire and another worker would start the working on the in progress job.
-
-```ruby
-NewsletterJob = Struct.new(:text, :emails) do
-  def perform
-    emails.each { |e| NewsletterMailer.deliver_text_to_email(text, e) }
-  end
-
-  def max_run_time
-    120 # seconds
-  end
-end
-```
-
 To set a per-job default for destroying failed jobs that overrides the Delayed::Worker.destroy_failed_jobs you can define a destroy_failed_jobs? method on the job
 
 ```ruby
@@ -428,9 +412,6 @@ On error, the job is scheduled again in 5 seconds + N ** 4, where N is the numbe
 The default `Worker.max_attempts` is 25. After this, the job either deleted (default), or left in the database with "failed_at" set.
 With the default of 25 attempts, the last retry will be 20 days later, with the last interval being almost 100 hours.
 
-The default `Worker.max_run_time` is 4.hours. If your job takes longer than that, another computer could pick it up. It's up to you to
-make sure your job doesn't exceed this time. You should set this to the longest time you think the job could take.
-
 By default, it will delete failed jobs (and it always deletes successful jobs). If you want to keep failed jobs, set
 `Delayed::Worker.destroy_failed_jobs = false`. The failed jobs will be marked with non-null failed_at.
 
@@ -461,7 +442,6 @@ Here is an example of changing job parameters in Rails:
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.sleep_delay = 60
 Delayed::Worker.max_attempts = 3
-Delayed::Worker.max_run_time = 5.minutes
 Delayed::Worker.read_ahead = 10
 Delayed::Worker.default_queue_name = 'default'
 Delayed::Worker.delay_jobs = !Rails.env.test?

--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -21,11 +21,11 @@ module Delayed
           end
         end
 
-        def reserve(worker, max_run_time = Worker.max_run_time)
+        def reserve(worker)
           # We get up to 5 jobs from the db. In case we cannot get exclusive access to a job we try the next.
           # this leads to a more even distribution of jobs across the worker processes
-          find_available(worker.name, worker.read_ahead, max_run_time).detect do |job|
-            job.lock_exclusively!(max_run_time, worker.name)
+          find_available(worker.name, worker.read_ahead).detect do |job|
+            job.lock_exclusively!(worker.name)
           end
         end
 
@@ -116,17 +116,6 @@ module Delayed
 
       def max_attempts
         payload_object.max_attempts if payload_object.respond_to?(:max_attempts)
-      end
-
-      def max_run_time
-        return unless payload_object.respond_to?(:max_run_time)
-        return unless (run_time = payload_object.max_run_time)
-
-        if run_time > Delayed::Worker.max_run_time
-          Delayed::Worker.max_run_time
-        else
-          run_time
-        end
       end
 
       def destroy_failed_jobs?

--- a/lib/delayed/deserialization_error.rb
+++ b/lib/delayed/deserialization_error.rb
@@ -1,4 +1,0 @@
-module Delayed
-  class DeserializationError < StandardError
-  end
-end

--- a/lib/delayed/exceptions.rb
+++ b/lib/delayed/exceptions.rb
@@ -1,3 +1,5 @@
 module Delayed
   FatalBackendError = Class.new(Exception)
+  InvalidCallback = Class.new(Exception)
+  DeserializationError = Class.new(StandardError)
 end

--- a/lib/delayed/exceptions.rb
+++ b/lib/delayed/exceptions.rb
@@ -1,12 +1,3 @@
-require 'timeout'
-
 module Delayed
-  class WorkerTimeout < Timeout::Error
-    def message
-      seconds = Delayed::Worker.max_run_time.to_i
-      "#{super} (Delayed::Worker.max_run_time is only #{seconds} second#{seconds == 1 ? '' : 's'})"
-    end
-  end
-
-  class FatalBackendError < Exception; end
+  FatalBackendError = Class.new(Exception)
 end

--- a/lib/delayed/lifecycle.rb
+++ b/lib/delayed/lifecycle.rb
@@ -1,6 +1,4 @@
 module Delayed
-  class InvalidCallback < Exception; end
-
   class Lifecycle
     EVENTS = {
       :enqueue    => [:job],

--- a/lib/delayed_job.rb
+++ b/lib/delayed_job.rb
@@ -15,7 +15,6 @@ require 'delayed/plugins/clear_locks'
 require 'delayed/backend/base'
 require 'delayed/backend/job_preparer'
 require 'delayed/worker'
-require 'delayed/deserialization_error'
 require 'delayed/railtie' if defined?(Rails::Railtie)
 
 Object.send(:include, Delayed::MessageSending)

--- a/lib/generators/delayed_job/delayed_job_generator.rb
+++ b/lib/generators/delayed_job/delayed_job_generator.rb
@@ -6,6 +6,6 @@ class DelayedJobGenerator < Rails::Generators::Base
 
   def create_executable_file
     template 'script', "#{Delayed::Compatibility.executable_prefix}/delayed_job"
-    chmod "#{Delayed::Compatibility.executable_prefix}/delayed_job", 0755
+    chmod "#{Delayed::Compatibility.executable_prefix}/delayed_job", 755
   end
 end

--- a/spec/delayed/backend/test.rb
+++ b/spec/delayed/backend/test.rb
@@ -58,7 +58,7 @@ module Delayed
         end
 
         # Find a few candidate jobs to run (in case some immediately get locked by others).
-        def self.find_available(worker_name, limit = 5) # rubocop:disable CyclomaticComplexity, PerceivedComplexity
+        def self.find_available(worker_name, limit = 5) # rubocop:disable CyclomaticComplexity
           jobs = all.select do |j|
             j.run_at <= db_time_now &&
               (j.locked_at.nil? || j.locked_by == worker_name) &&

--- a/spec/delayed/backend/test.rb
+++ b/spec/delayed/backend/test.rb
@@ -58,10 +58,10 @@ module Delayed
         end
 
         # Find a few candidate jobs to run (in case some immediately get locked by others).
-        def self.find_available(worker_name, limit = 5, max_run_time = Worker.max_run_time) # rubocop:disable CyclomaticComplexity, PerceivedComplexity
+        def self.find_available(worker_name, limit = 5) # rubocop:disable CyclomaticComplexity, PerceivedComplexity
           jobs = all.select do |j|
             j.run_at <= db_time_now &&
-              (j.locked_at.nil? || j.locked_at < db_time_now - max_run_time || j.locked_by == worker_name) &&
+              (j.locked_at.nil? || j.locked_by == worker_name) &&
               !j.failed?
           end
           jobs.select! { |j| j.priority <= Worker.max_priority } if Worker.max_priority
@@ -72,7 +72,7 @@ module Delayed
 
         # Lock this job for this worker.
         # Returns true if we have the lock, false otherwise.
-        def lock_exclusively!(_max_run_time, worker)
+        def lock_exclusively!(worker)
           now = self.class.db_time_now
           if locked_by != worker
             # We don't own this job so we will update the locked_by name and the locked_at

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -52,13 +52,13 @@ describe Delayed::Worker do
     end
 
     it 'reads five jobs' do
-      expect(Delayed::Job).to receive(:find_available).with(anything, 5, anything).and_return([])
+      expect(Delayed::Job).to receive(:find_available).with(anything, 5).and_return([])
       Delayed::Job.reserve(Delayed::Worker.new)
     end
 
     it 'reads a configurable number of jobs' do
       Delayed::Worker.read_ahead = 15
-      expect(Delayed::Job).to receive(:find_available).with(anything, Delayed::Worker.read_ahead, anything).and_return([])
+      expect(Delayed::Job).to receive(:find_available).with(anything, Delayed::Worker.read_ahead).and_return([])
       Delayed::Job.reserve(Delayed::Worker.new)
     end
   end


### PR DESCRIPTION
Hi,

There are a lot of problems with Ruby `Timeout`. It basically raises an exception on the main thread after sleeping in another thread for `N` seconds. It means that your code in `Timeout` block can be interrupted in any line. So, for example, database state can be easily corrupted during network operations. 

In my application I have to deal with opened database transaction manually to make sure that it closed after a `Timeout::Error` exception, something like this:

```ruby
callbacks do |lifecycle|
  lifecycle.after(:error) do |worker, job, &block|
    ensure_transaction_finished_correctly
  end
end

def ensure_transaction_finished_correctly # ActiveRecord 4.2
  transaction_manager = Delayed::Job.connection.transaction_manager
  return if transaction_manager.current_transaction == transaction_manager.class::NULL_TRANSACTION

  transaction_manager.rollback_transaction
end
```

However, there are still no guarantees that it will work correctly.

There are a lot of blog posts in which authors complain about `Timeout`:

* [Why Ruby’s Timeout is dangerous (and Thread.raise is terrifying)](http://jvns.ca/blog/2015/11/27/why-rubys-timeout-is-dangerous-and-thread-dot-raise-is-terrifying/)
> Nobody writes code to defend against an exception being raised on literally any line. That's not even possible. So Thread.raise is basically like a sneak attack on your code that could result in almost anything. It would probably be okay if it were pure-functional code that did not modify any state. But this is Ruby, so that's unlikely :)

* [Timeout: Ruby's Most Dangerous API](http://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/)
> All were caused by the same thing: Ruby’s terrible Timeout module. I strongly urge everyone reading this to remove any usage of Timeout from your codebase; odds are very good you will see an increase in stability.

* [Ruby's Thread#raise, Thread#kill, timeout.rb, and net/protocol.rb libraries are broken](http://blog.headius.com/2008/02/rubys-threadraise-threadkill-timeoutrb.html)
> I'm hoping this will start a discussion eventually leading to these features being deprecated and removed from use.

I really hope we remove `Timeout` from `DelayedJob`, even if it's a breaking change.

P. S. Sidekiq has already [done it] (https://github.com/mperham/sidekiq/issues/862) 😺 
