### PR TITLE
Allow graceful interruption of worker sleep

### DIFF
--- a/lib/delayed/event.rb
+++ b/lib/delayed/event.rb
@@ -1,0 +1,42 @@
+module Delayed
+  # Implements an auto-reset event.
+  #
+  # Event is a semaphore-like thread synchronization object with auto-reset
+  # capability. One thread sets the event and another one waits on it with a
+  # timeout.
+  class Event
+    def initialize
+      @mutex = Mutex.new
+      @condition = ConditionVariable.new
+      @value = false
+    end
+
+    # Set the event and wake up one thread.
+    def set!
+      @mutex.synchronize do
+        @value = true
+        @condition.signal
+      end
+    end
+
+    # Wait for event to be set.
+    #
+    # Event#wait will wait until the event is set, with a timeout. If the
+    # timeout elapses it returns false. Otherwise it returns true and resets the
+    # event.
+    def wait(timeout)
+      target = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+
+      @mutex.synchronize do
+        until @value
+          timeout = target - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          break if timeout <= 0
+          @condition.wait(@mutex, timeout)
+        end
+        result = @value
+        @value = false
+        result
+      end
+    end
+  end
+end


### PR DESCRIPTION
When daemonized through `Delayed::Command` `Delayed::Worker` will ignore signals every time it sleeps after detecting an empty queue. That's specially problematic when using a long `sleep_delay` (30+ seconds) with a predominantly idle queue, because the Daemons gem will forcefully kill the process if it's not responsive.

Another way the issue manifests is when executing something like the following:

    Delayed::Worker.sleep_delay = 30.seconds
    Delayed::Command.new(['run']).daemonize

Trying to stop the command with `Ctrl-C` outputs a message `Exiting...`, but nothing else happens, apparently. The command does stop, however, after the full `sleep_delay` interval elapses.

The root cause is a [`sleep` call](https://github.com/collectiveidea/delayed_job/blob/2026cd46ce17192cd8efd876044e2e140fe7b603/lib/delayed/worker.rb#L186) in `Delayed::Worker`, which cannot be interrupted unless a signal is raised. Since raising signals is often undesirable because it might also interrupt unfinished jobs we need to address only the case when `Delayed::Worker` is sleeping.

This patch offers a solution, which consists in substituting the sleep call with a wait on an event. Setting the event from the trap enables the worker to exit immediately. Otherwise, if the timeout given to the wait call elapses, everything behaves as if sleep was called.

This resolves the issue #593 and may also be related to #459 and #916.