### PR TITLE
Use ActiveSupport::Reloader in Rails 5

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -320,8 +320,12 @@ module Delayed
 
     def reload!
       return unless self.class.reload_app?
-      ActionDispatch::Reloader.cleanup!
-      ActionDispatch::Reloader.prepare!
+      if defined?(ActiveSupport::Reloader)
+        Rails.application.reloader.reload!
+      else
+        ActionDispatch::Reloader.cleanup!
+        ActionDispatch::Reloader.prepare!
+      end
     end
   end
 end


### PR DESCRIPTION
Rails 5.1 will remove the cleanup! and prepare! methods from ActionDispatch::Reloader, as they have been replaced with ActiveSupport::Reloader reload!.

```
DEPRECATION WARNING: cleanup! is deprecated and will be removed from Rails 5.1 (use Rails.application.reloader.reload! instead of cleanup + prepare) (called from <main> at bin/delayed_job:5)
DEPRECATION WARNING: prepare! is deprecated and will be removed from Rails 5.1 (use Rails.application.reloader.prepare! instead) (called from <main> at bin/delayed_job:5)
```
