### PR TITLE
Require 'active_support' at first

### DIFF
--- a/lib/delayed_job.rb
+++ b/lib/delayed_job.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'delayed/compatibility'
 require 'delayed/exceptions'
 require 'delayed/message_sending'


### PR DESCRIPTION
### Summary

Require `active_support`, at first.
### Problem

Outside the rails framework, failed to load `delayed_job` in spite of supporting `active_support` > 5.0.0.
like this.

``` ruby
% irb
irb(main):001:0> require 'bundler/setup'
=> true
irb(main):002:0> require './lib/delayed_job'
NoMethodError: undefined method `instance' for ActiveSupport::Deprecation:Class
Did you mean?  instance_of?
        from /Users/argerich/dev/delayed_job/vendor/bundle/gems/activesupport-5.0.0/lib/active_support/deprecation/proxy_wrappers.rb:124:in `initialize'
        from /Users/argerich/dev/delayed_job/vendor/bundle/gems/activesupport-5.0.0/lib/active_support/deprecation/proxy_wrappers.rb:10:in `new'
        from /Users/argerich/dev/delayed_job/vendor/bundle/gems/activesupport-5.0.0/lib/active_support/deprecation/proxy_wrappers.rb:10:in `new'
        from /Users/argerich/dev/delayed_job/vendor/bundle/gems/activesupport-5.0.0/lib/active_support/core_ext/load_error.rb:30:in `<top (required)>'
        from /Users/argerich/dev/delayed_job/vendor/bundle/gems/activesupport-5.0.0/lib/active_support/dependencies.rb:12:in `require'
        from /Users/argerich/dev/delayed_job/vendor/bundle/gems/activesupport-5.0.0/lib/active_support/dependencies.rb:12:in `<top (required)>'
        from /Users/argerich/dev/delayed_job/lib/delayed/worker.rb:2:in `require'
        from /Users/argerich/dev/delayed_job/lib/delayed/worker.rb:2:in `<top (required)>'
        from /Users/argerich/dev/delayed_job/lib/delayed_job.rb:17:in `require'
        from /Users/argerich/dev/delayed_job/lib/delayed_job.rb:17:in `<top (required)>'
        from (irb):2:in `require'
        from (irb):2
        from /Users/argerich/.rbenv/versions/2.3.1/bin/irb:11:in `<main>'
```

I think that it is bad to failed to load top level `delayed_job` file.

The cause is that you failed to load only `active_support/dependencies` without require top level file `active_support`.
I think that  you use stand alone `active_support`, must require the top level file like this `require 'active_support'` according to  http://guides.rubyonrails.org/active_support_core_extensions.html#stand-alone-active-support

In particular, occur this problem when Rails application > 5.0.0 deploies by `capistrano` with `bugsnag/capistrano`.
Because `capistrano` normally doesn't load rails environments, so doesn't load top level file `active_support`.

``` zsh
$ cap vm deploy --trace
cap aborted!
NoMethodError: undefined method `instance' for ActiveSupport::Deprecation:Class
Did you mean?  instance_of?
/Users/argerich/work/sample-app/vendor/bundle/gems/activesupport-5.0.0/lib/active_support/deprecation/proxy_wrappers.rb:124:in `initialize'
/Users/argerich/work/sample-app/vendor/bundle/gems/activesupport-5.0.0/lib/active_support/deprecation/proxy_wrappers.rb:10:in `new'
/Users/argerich/work/sample-app/vendor/bundle/gems/activesupport-5.0.0/lib/active_support/deprecation/proxy_wrappers.rb:10:in `new'
/Users/argerich/work/sample-app/vendor/bundle/gems/activesupport-5.0.0/lib/active_support/core_ext/load_error.rb:30:in `<top (required)>'
/Users/argerich/work/sample-app/vendor/bundle/gems/activesupport-5.0.0/lib/active_support/dependencies.rb:12:in `require'
/Users/argerich/work/sample-app/vendor/bundle/gems/activesupport-5.0.0/lib/active_support/dependencies.rb:12:in `<top (required)>'
/Users/argerich/work/sample-app/vendor/bundle/gems/delayed_job-4.1.2/lib/delayed/worker.rb:2:in `require'
/Users/argerich/work/sample-app/vendor/bundle/gems/delayed_job-4.1.2/lib/delayed/worker.rb:2:in `<top (required)>'
/Users/argerich/work/sample-app/vendor/bundle/gems/delayed_job-4.1.2/lib/delayed_job.rb:17:in `require'
/Users/argerich/work/sample-app/vendor/bundle/gems/delayed_job-4.1.2/lib/delayed_job.rb:17:in `<top (required)>'
/Users/argerich/work/sample-app/vendor/bundle/gems/bugsnag-4.2.1/lib/bugsnag/delayed_job.rb:1:in `require'
/Users/argerich/work/sample-app/vendor/bundle/gems/bugsnag-4.2.1/lib/bugsnag/delayed_job.rb:1:in `<top (required)>'
/Users/argerich/work/sample-app/vendor/bundle/gems/bugsnag-4.2.1/lib/bugsnag.rb:134:in `require'
/Users/argerich/work/sample-app/vendor/bundle/gems/bugsnag-4.2.1/lib/bugsnag.rb:134:in `block in <top (required)>'
/Users/argerich/work/sample-app/vendor/bundle/gems/bugsnag-4.2.1/lib/bugsnag.rb:132:in `each'
/Users/argerich/work/sample-app/vendor/bundle/gems/bugsnag-4.2.1/lib/bugsnag.rb:132:in `<top (required)>'
/Users/argerich/work/sample-app/vendor/bundle/gems/bugsnag-4.2.1/lib/bugsnag/capistrano.rb:1:in `require'
/Users/argerich/work/sample-app/vendor/bundle/gems/bugsnag-4.2.1/lib/bugsnag/capistrano.rb:1:in `<top (required)>'
/Users/argerich/work/sample-app/Capfile:33:in `require'
/Users/argerich/work/sample-app/Capfile:33:in `<top (required)>'
/Users/argerich/work/sample-app/vendor/bundle/gems/rake-11.2.2/lib/rake/rake_module.rb:28:in `load'
/Users/argerich/work/sample-app/vendor/bundle/gems/rake-11.2.2/lib/rake/rake_module.rb:28:in `load_rakefile'
/Users/argerich/work/sample-app/vendor/bundle/gems/rake-11.2.2/lib/rake/application.rb:686:in `raw_load_rakefile'
/Users/argerich/work/sample-app/vendor/bundle/gems/rake-11.2.2/lib/rake/application.rb:96:in `block in load_rakefile'
/Users/argerich/work/sample-app/vendor/bundle/gems/rake-11.2.2/lib/rake/application.rb:178:in `standard_exception_handling'
/Users/argerich/work/sample-app/vendor/bundle/gems/rake-11.2.2/lib/rake/application.rb:95:in `load_rakefile'
/Users/argerich/work/sample-app/vendor/bundle/gems/rake-11.2.2/lib/rake/application.rb:79:in `block in run'
/Users/argerich/work/sample-app/vendor/bundle/gems/rake-11.2.2/lib/rake/application.rb:178:in `standard_exception_handling'
/Users/argerich/work/sample-app/vendor/bundle/gems/rake-11.2.2/lib/rake/application.rb:77:in `run'
/Users/argerich/work/sample-app/vendor/bundle/gems/capistrano-3.5.0/lib/capistrano/application.rb:14:in `run'
/Users/argerich/work/sample-app/vendor/bundle/gems/capistrano-3.5.0/bin/cap:3:in `<top (required)>'
/Users/argerich/work/sample-app/vendor/bundle/bin/cap:17:in `load'
/Users/argerich/work/sample-app/vendor/bundle/bin/cap:17:in `<main>'
```
