### PR TITLE
Update run_process to bypass daemons if the run command is used.  

### DIFF
--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -118,9 +118,14 @@ module Delayed
 
     def run_process(process_name, options = {})
       Delayed::Worker.before_fork
-      Daemons.run_proc(process_name, :dir => options[:pid_dir], :dir_mode => :normal, :monitor => @monitor, :ARGV => @args) do |*_args|
-        $0 = File.join(options[:prefix], process_name) if @options[:prefix]
+
+      if @args.include? "run"
         run process_name, options
+      else
+        Daemons.run_proc(process_name, :dir => options[:pid_dir], :dir_mode => :normal, :monitor => @monitor, :ARGV => @args) do |*_args|
+          $0 = File.join(options[:prefix], process_name) if @options[:prefix]
+          run process_name, options
+        end
       end
     end
 


### PR DESCRIPTION
Daemons breaks Rails with fsevent_watch by attempting to close all IO objects in ObjectSpace.

Fixes #935 
