### PR TITLE
Add callback on reservation of the job

### DIFF
--- a/lib/delayed/lifecycle.rb
+++ b/lib/delayed/lifecycle.rb
@@ -6,6 +6,7 @@ module Delayed
       :enqueue    => [:job],
       :execute    => [:worker],
       :loop       => [:worker],
+      :reserve    => [:worker],
       :perform    => [:worker, :job],
       :error      => [:worker, :job],
       :failure    => [:worker, :job],

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -302,7 +302,7 @@ module Delayed
     # Run the next job we can get an exclusive lock on.
     # If no jobs are left we return nil
     def reserve_and_run_one_job
-      job = reserve_job
+      job = self.class.lifecycle.run_callbacks(:reserve, self) { reserve_job }
       self.class.lifecycle.run_callbacks(:perform, self, job) { run(job) } if job
     end
 


### PR DESCRIPTION
That way it would be possible to hook into reservation so that it's
possible to write a plugin that logs or measures the time of job
reservation and so on.
