### PR TITLE
Fixes #946 - Delayed Job fails if original object soft-deleted

### DIFF
--- a/lib/delayed/psych_ext.rb
+++ b/lib/delayed/psych_ext.rb
@@ -37,7 +37,7 @@ module Delayed
             klass = result.class
             id = result[klass.primary_key]
             begin
-              klass.find(id)
+              klass.unscoped.find(id)
             rescue ActiveRecord::RecordNotFound => error # rubocop:disable BlockNesting
               raise Delayed::DeserializationError, "ActiveRecord::RecordNotFound, class: #{klass}, primary key: #{id} (#{error.message})"
             end


### PR DESCRIPTION
Makes psych_ext.rb#40 behave consistently to #53 to handle soft-deleted objects
