### PR TITLE
Fix cleanup! and prepare! Deprecations with Rails 5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,13 +17,16 @@ AllCops:
 RedundantBlockCall:
   Enabled: false
 
+BlockLength:
+  Enabled: false
+
 # Avoid more than `Max` levels of nesting.
 BlockNesting:
   Max: 2
 
 # Indentation of when/else
 CaseIndentation:
-  IndentWhenRelativeTo: end
+  EnforcedStyle: end
   IndentOneStep: false
 
 ClassLength:
@@ -49,6 +52,10 @@ DotPosition:
 DoubleNegation:
   Enabled: false
 
+# Detects any duplication as issue including our conditional requires
+DuplicatedGem:
+  Enabled: false
+
 EmptyLinesAroundAccessModifier:
   Enabled: true
 
@@ -58,7 +65,7 @@ Encoding:
 
 # Align ends correctly
 EndAlignment:
-  AlignWith: variable
+  EnforcedStyleAlignWith: variable
 
 # Enforce Ruby 1.8-compatible hash syntax
 HashSyntax:
@@ -117,6 +124,9 @@ TrailingCommaInLiteral:
   Enabled: false
 
 TrailingCommaInArguments:
+  Enabled: false
+
+YAMLLoad:
   Enabled: false
 
 ZeroLengthPredicate:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
     - RAILS_VERSION="~> 4.0.0"
     - RAILS_VERSION="~> 4.1.0"
     - RAILS_VERSION="~> 4.2.0"
-    - RAILS_VERSION="~> 5.0.0.beta1"
+    - RAILS_VERSION="~> 5.0.0"
     - RAILS_VERSION="edge"
 rvm:
   - 2.0.0
@@ -41,8 +41,8 @@ matrix:
 
   exclude:
     - rvm: 2.0.0
-      env: RAILS_VERSION="~> 5.0.0.beta1"
+      env: RAILS_VERSION="~> 5.0.0"
     - rvm: 2.1
-      env: RAILS_VERSION="~> 5.0.0.beta1"
+      env: RAILS_VERSION="~> 5.0.0"
 
 sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :test do
 
   gem 'coveralls', :require => false
   gem 'rspec', '>= 3'
-  gem 'rubocop', '0.25'
+  gem 'rubocop', '>= 0.25'
   gem 'simplecov', '>= 0.9'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+rails_version = ENV['RAILS_VERSION'] || ''
+
 gem 'rake'
 
 platforms :ruby do
@@ -8,7 +10,13 @@ end
 
 platforms :jruby do
   gem 'jruby-openssl'
-  gem 'activerecord-jdbcsqlite3-adapter'
+  if rails_version == 'edge' || rails_version.match(/5\.\d+\.\d+/)
+    gem 'activerecord-jdbcsqlite3-adapter',
+        :git => 'https://github.com/jruby/activerecord-jdbc-adapter.git',
+        :branch => 'rails-5'
+  else
+    gem 'activerecord-jdbcsqlite3-adapter'
+  end
   gem 'mime-types', ['~> 2.6', '< 2.99']
 end
 
@@ -18,16 +26,16 @@ end
 
 group :test do
   if ENV['RAILS_VERSION'] == 'edge'
-    gem 'activerecord', :github => 'rails/rails'
     gem 'actionmailer', :github => 'rails/rails'
+    gem 'activerecord', :github => 'rails/rails'
   else
-    gem 'activerecord', (ENV['RAILS_VERSION'] || ['>= 3.0', '< 5.1'])
     gem 'actionmailer', (ENV['RAILS_VERSION'] || ['>= 3.0', '< 5.1'])
+    gem 'activerecord', (ENV['RAILS_VERSION'] || ['>= 3.0', '< 5.1'])
   end
 
   gem 'coveralls', :require => false
   gem 'rspec', '>= 3'
-  gem 'rubocop', '>= 0.25'
+  gem 'rubocop', '0.25'
   gem 'simplecov', '>= 0.9'
 end
 

--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -30,16 +30,13 @@ module Delayed
         end
 
         # Allow the backend to attempt recovery from reserve errors
-        def recover_from(_error)
-        end
+        def recover_from(_error); end
 
         # Hook method that is called before a new worker is forked
-        def before_fork
-        end
+        def before_fork; end
 
         # Hook method that is called after a new worker is forked
-        def after_fork
-        end
+        def after_fork; end
 
         def work_off(num = 100)
           warn '[DEPRECATION] `Delayed::Job.work_off` is deprecated. Use `Delayed::Worker.new.work_off instead.'
@@ -101,7 +98,7 @@ module Delayed
       def hook(name, *args)
         if payload_object.respond_to?(name)
           method = payload_object.method(name)
-          method.arity == 0 ? method.call : method.call(self, *args)
+          method.arity.zero? ? method.call : method.call(self, *args)
         end
       rescue DeserializationError # rubocop:disable HandleExceptions
       end

--- a/lib/delayed/backend/job_preparer.rb
+++ b/lib/delayed/backend/job_preparer.rb
@@ -42,9 +42,11 @@ module Delayed
           options[:run_at]   = args[1]
         end
 
+        # rubocop:disable GuardClause
         unless options[:payload_object].respond_to?(:perform)
           raise ArgumentError, 'Cannot enqueue items which do not respond to perform'
         end
+        # rubocop:enabled GuardClause
       end
     end
   end

--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -91,11 +91,13 @@ module Delayed
       if worker_pools
         setup_pools
       elsif @options[:identifier]
+        # rubocop:disable GuardClause
         if worker_count > 1
           raise ArgumentError, 'Cannot specify both --number-of-workers and --identifier'
         else
           run_process("delayed_job.#{@options[:identifier]}", @options)
         end
+        # rubocop:enable GuardClause
       else
         worker_count.times do |worker_index|
           process_name = worker_count == 1 ? 'delayed_job' : "delayed_job.#{worker_index}"

--- a/lib/delayed/exceptions.rb
+++ b/lib/delayed/exceptions.rb
@@ -8,5 +8,5 @@ module Delayed
     end
   end
 
-  class FatalBackendError < Exception; end
+  class FatalBackendError < RuntimeError; end
 end

--- a/lib/delayed/lifecycle.rb
+++ b/lib/delayed/lifecycle.rb
@@ -1,5 +1,5 @@
 module Delayed
-  class InvalidCallback < Exception; end
+  class InvalidCallback < RuntimeError; end
 
   class Lifecycle
     EVENTS = {

--- a/lib/delayed/message_sending.rb
+++ b/lib/delayed/message_sending.rb
@@ -6,9 +6,11 @@ module Delayed
       @options = options
     end
 
+    # rubocop:disable MethodMissing
     def method_missing(method, *args)
       Job.enqueue({:payload_object => @payload_class.new(@target, method.to_sym, args)}.merge(@options))
     end
+    # rubocop:enable MethodMissing
   end
 
   module MessageSending

--- a/lib/delayed/performable_method.rb
+++ b/lib/delayed/performable_method.rb
@@ -30,9 +30,11 @@ module Delayed
       object.method(sym)
     end
 
+    # rubocop:disable MethodMissing
     def method_missing(symbol, *args)
       object.send(symbol, *args)
     end
+    # rubocop:enable MethodMissing
 
     def respond_to?(symbol, include_private = false)
       super || object.respond_to?(symbol, include_private)

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -320,8 +320,12 @@ module Delayed
 
     def reload!
       return unless self.class.reload_app?
-      ActionDispatch::Reloader.cleanup!
-      ActionDispatch::Reloader.prepare!
+      if defined?(ActiveSupport::Reloader)
+        Rails.application.reloader.reload!
+      else
+        ActionDispatch::Reloader.cleanup!
+        ActionDispatch::Reloader.prepare!
+      end
     end
   end
 end

--- a/lib/generators/delayed_job/delayed_job_generator.rb
+++ b/lib/generators/delayed_job/delayed_job_generator.rb
@@ -6,6 +6,6 @@ class DelayedJobGenerator < Rails::Generators::Base
 
   def create_executable_file
     template 'script', "#{Delayed::Compatibility.executable_prefix}/delayed_job"
-    chmod "#{Delayed::Compatibility.executable_prefix}/delayed_job", 0755
+    chmod "#{Delayed::Compatibility.executable_prefix}/delayed_job", 0o755
   end
 end

--- a/spec/autoloaded/clazz.rb
+++ b/spec/autoloaded/clazz.rb
@@ -1,7 +1,6 @@
 # Make sure this file does not get required manually
 module Autoloaded
   class Clazz
-    def perform
-    end
+    def perform; end
   end
 end

--- a/spec/autoloaded/instance_clazz.rb
+++ b/spec/autoloaded/instance_clazz.rb
@@ -1,6 +1,5 @@
 module Autoloaded
   class InstanceClazz
-    def perform
-    end
+    def perform; end
   end
 end

--- a/spec/autoloaded/instance_struct.rb
+++ b/spec/autoloaded/instance_struct.rb
@@ -1,7 +1,6 @@
 module Autoloaded
   InstanceStruct = ::Struct.new(nil)
   class InstanceStruct
-    def perform
-    end
+    def perform; end
   end
 end

--- a/spec/autoloaded/struct.rb
+++ b/spec/autoloaded/struct.rb
@@ -2,7 +2,6 @@
 module Autoloaded
   Struct = ::Struct.new(nil)
   class Struct
-    def perform
-    end
+    def perform; end
   end
 end

--- a/spec/message_sending_spec.rb
+++ b/spec/message_sending_spec.rb
@@ -42,8 +42,7 @@ describe Delayed::MessageSending do
       describe 'using a proc with parameters' do
         class Yarn
           attr_accessor :importance
-          def spin
-          end
+          def spin; end
           handle_asynchronously :spin, :priority => proc { |y| y.importance }
         end
 

--- a/spec/performable_method_spec.rb
+++ b/spec/performable_method_spec.rb
@@ -30,8 +30,7 @@ describe Delayed::PerformableMethod do
 
   it 'does not raise NoMethodError if target method is private' do
     clazz = Class.new do
-      def private_method
-      end
+      def private_method; end
       private :private_method
     end
     expect { Delayed::PerformableMethod.new(clazz.new, :private_method, []) }.not_to raise_error


### PR DESCRIPTION
Rails 5 deprecates `cleanup!` and `prepare!` causing a large amount of log spam from Delayed::Job:

```
DEPRECATION WARNING: cleanup! is deprecated and will be removed from Rails 5.1 (use Rails.application.reloader.reload! instead of cleanup + prepare) (called from require at bin/rails:9)
DEPRECATION WARNING: prepare! is deprecated and will be removed from Rails 5.1 (use Rails.application.reloader.prepare! instead) (called from require at bin/rails:9)
```

The first commit fixes existing issues with rubocop. Any easy corrections were made. Those that required refactorings were disabled.
