### PR TITLE
use identifier and num option in same time

### DIFF
--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -88,7 +88,10 @@ module Delayed
         setup_pools
       elsif @options[:identifier]
         if worker_count > 1
-          raise ArgumentError, 'Cannot specify both --number-of-workers and --identifier'
+          worker_count.times do |worker_index|
+            process_name = "delayed_job.#{@options[:identifier]}#{worker_index}"
+            run_process(process_name, @options)
+          end
         else
           run_process("delayed_job.#{@options[:identifier]}", @options)
         end


### PR DESCRIPTION
Currently, we cannot use num and identifier options in same time. But it will be enable if set process_name as `delayed_job.#{@options[:identifier]}#{worker_index}`.

The pool option is ok, but we cannot detect which worker is running for which queue. 

```
$ bundle exec bin/delayed_job --pool=mailers:2 --pool=default:2 start
delayed_job.0: process with pid 12992 started.
delayed_job.1: process with pid 12994 started.
delayed_job.2: process with pid 12996 started.
delayed_job.3: process with pid 12998 started.

$ ps aux | grep [d]elay
kenjiszk        12998  22.3  2.1  2679988 179992   ??  S    11:19PM   0:02.52 delayed_job.3      
kenjiszk        12996   9.9  2.1  2676916 176792   ??  S    11:19PM   0:02.69 delayed_job.2      
kenjiszk        12994   6.0  2.1  2670772 173492   ??  S    11:19PM   0:02.75 delayed_job.1      
kenjiszk        12992   1.9  2.1  2671796 174548   ??  S    11:19PM   0:02.70 delayed_job.0
```

This PR samples are followings.

```
$ bundle exec bin/delayed_job -n 2 -i mailers --queue=mailers start
delayed_job.mailers0: process with pid 12918 started.
delayed_job.mailers1: process with pid 12920 started.

$ bundle exec bin/delayed_job -n 2 -i default --queue=default start
delayed_job.default0: process with pid 12943 started.
delayed_job.default1: process with pid 12945 started.

$ ps aux | grep [d]elay
kenjiszk        12920  11.4  1.9  2666676 162916   ??  U    11:17PM   0:04.56 delayed_job.mailers1         
kenjiszk        12918  10.2  2.0  2665652 170820   ??  R    11:17PM   0:04.81 delayed_job.mailers0         
kenjiszk        12945   0.0  2.1  2675892 178828   ??  S    11:17PM   0:02.35 delayed_job.default1         
kenjiszk        12943   0.0  2.2  2683060 184472   ??  S    11:17PM   0:02.47 delayed_job.default0
```
