### PR TITLE
Be more explicity about WorkerTimeout Exception

### DIFF
--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -547,6 +547,18 @@ shared_examples_for 'a delayed_job backend' do
         expect(job.attempts).to eq(1)
       end
 
+      it 'fails after Job#max_run_time' do
+        Delayed::Worker.max_run_time = 3.seconds
+        long_running_job = LongRunningJob.new
+        allow(long_running_job).to receive(:max_run_time) { 1.second }
+        job = Delayed::Job.create :payload_object => long_running_job
+        worker.run(job)
+        expect(job.error).to_not be_nil
+        expect(job.reload.last_error).to match(/expired/)
+        expect(job.reload.last_error).to match(/LongRunningJob#max_run_time is only 1 second/)
+        expect(job.attempts).to eq(1)
+      end
+
       context 'when the job raises a deserialization error' do
         after do
           Delayed::Worker.destroy_failed_jobs = true

--- a/lib/delayed/exceptions.rb
+++ b/lib/delayed/exceptions.rb
@@ -2,9 +2,29 @@ require 'timeout'
 
 module Delayed
   class WorkerTimeout < Timeout::Error
+    attr_reader :job, :seconds
+
+    def initialize(job, seconds)
+      @job = job
+      @seconds = seconds
+    end
+
     def message
-      seconds = Delayed::Worker.max_run_time.to_i
-      "#{super} (Delayed::Worker.max_run_time is only #{seconds} second#{seconds == 1 ? '' : 's'})"
+      "execution expired (#{source_max_run_time} is only #{seconds_to_s}"
+    end
+
+  private
+
+    def source_max_run_time
+      job_timeout? ? "#{job.name}#max_run_time" : 'Delayed::Worker.max_run_time'
+    end
+
+    def job_timeout?
+      job.max_run_time
+    end
+
+    def seconds_to_s
+      "#{@seconds} second#{seconds == 1 ? '' : 's'}"
     end
   end
 


### PR DESCRIPTION
Currently the `Delayed::WorkerTimeout` Exception is confusing as it only considers `Delayed::Worker.max_run_time` for its message, even though the timeout might have been caused by `max_run_time` set on the particular job. 

This PR adjusts the message to give more details about which of the two timeouts caused the error.