### PR TITLE
Default destroy_failed_jobs, DEFAULT_MAX_ATTEMPTS to better values

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -50,7 +50,7 @@ module Delayed
 
     # By default failed jobs are destroyed after too many attempts. If you want to keep them around
     # (perhaps to inspect the reason for the failure), set this to false.
-    self.destroy_failed_jobs = true
+    self.destroy_failed_jobs = false
 
     # By default, Signals INT and TERM set @exit, and the worker exits upon completion of the current job.
     # If you would prefer to raise a SignalException and exit immediately you can use this.

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -11,7 +11,7 @@ module Delayed
   class Worker # rubocop:disable ClassLength
     DEFAULT_LOG_LEVEL        = 'info'.freeze
     DEFAULT_SLEEP_DELAY      = 5
-    DEFAULT_MAX_ATTEMPTS     = 25
+    DEFAULT_MAX_ATTEMPTS     = 3
     DEFAULT_MAX_RUN_TIME     = 4.hours
     DEFAULT_DEFAULT_PRIORITY = 0
     DEFAULT_DELAY_JOBS       = true


### PR DESCRIPTION
Deleting failed jobs after 25 attempts, both by default, is extreme. Since most people don't RTFM, letting failed jobs persist and trying only three times surface potential problems sooner.