### PR TITLE
Adds additional rake task to clear jobs from a specific queue

### DIFF
--- a/lib/delayed/tasks.rb
+++ b/lib/delayed/tasks.rb
@@ -4,6 +4,11 @@ namespace :jobs do
     Delayed::Job.delete_all
   end
 
+  desc 'Clear jobs from a named queue.'
+  task :clear_queue, [:queue_name] => :environment do |_,args|  
+    Delayed::Job.where(queue: args[:queue_name]).destroy_all
+  end   
+
   desc 'Start a delayed_job worker.'
   task :work => :environment_options do
     Delayed::Worker.new(@worker_options).start


### PR DESCRIPTION
Currently, the **'jobs:clear**' task clears all the records from the delayed_job table however, there will be scenarios where jobs only from a specific queue need to be cleared.

ex: restarting (post-maintenance) you would only want to clear WebSocket jobs (news feed) but not subscription charges job (monthly billing).

this pull request adds an additional rake task that accepts a parameter(queue_name) and clears the jobs from the queue.