### PR TITLE
Fix quiet mode working incorrectly when ENV['QUIET'] was not set

### DIFF
--- a/lib/delayed/tasks.rb
+++ b/lib/delayed/tasks.rb
@@ -18,10 +18,10 @@ namespace :jobs do
     @worker_options = {
       :min_priority => ENV['MIN_PRIORITY'],
       :max_priority => ENV['MAX_PRIORITY'],
-      :queues => (ENV['QUEUES'] || ENV['QUEUE'] || '').split(','),
-      :quiet => ENV['QUIET']
+      :queues => (ENV['QUEUES'] || ENV['QUEUE'] || '').split(',')
     }
 
+    @worker_options[:quiet] = ENV['QUIET'] if ENV['QUIET']
     @worker_options[:sleep_delay] = ENV['SLEEP_DELAY'].to_i if ENV['SLEEP_DELAY']
     @worker_options[:read_ahead] = ENV['READ_AHEAD'].to_i if ENV['READ_AHEAD']
   end


### PR DESCRIPTION
In our environment we were seeing duplicated log entries in Loggly that looked like this:

```
2017-06-22 16:20:57.598 2017-06-22T16:20:57-0700: [Worker(host:436c039f-cf12-4c5b-93b8-4fd517b2c2ea pid:4)] Job Module#partial_update_bulk_index (id=71153821) RUNNING{ http: { clientHost: "54.90.183.112", contentType: "application/logplex-1" }, syslog: { severity: "Informational", appName: "app", host: "host", procid: "elasticindex.3", priority: "190", facility: "local use 7", timestamp: "2017-06-22T23:20:57.598127+00:00" } }
2017-06-22 16:20:57.598 [Worker(host:436c039f-cf12-4c5b-93b8-4fd517b2c2ea pid:4)] Job Module#partial_update_bulk_index (id=71153821) RUNNING{ http: { clientHost: "54.90.183.112", contentType: "application/logplex-1" }, syslog: { severity: "Informational", appName: "app", host: "host", procid: "elasticindex.3", priority: "190", facility: "local use 7", timestamp: "2017-06-22T23:20:57.598060+00:00" } }
```

Despite what looked like correct settings, it turns out that if ENV['QUIET'] is *not* set when starting Delayed Job via `rake jobs:work`, `Delayed::Worker` doesn't default `@quiet` to `true`. It appears the intended behavior is to default to true if ENV['QUIET'] is not set, so this change fixes this bug.

I could be reading the code wrong, let me know, thanks!