### PR TITLE
rake jobs:check should not consider jobs scheduled to run in the future

### DIFF
--- a/lib/delayed/tasks.rb
+++ b/lib/delayed/tasks.rb
@@ -30,7 +30,7 @@ namespace :jobs do
   task :check, [:max_age] => :environment do |_, args|
     args.with_defaults(:max_age => 300)
 
-    unprocessed_jobs = Delayed::Job.where('attempts = 0 AND created_at < ?', Time.now - args[:max_age].to_i).count
+    unprocessed_jobs = Delayed::Job.where('attempts = 0 AND run_at < ?', Time.now - args[:max_age].to_i).count
 
     if unprocessed_jobs > 0
       raise "#{unprocessed_jobs} jobs older than #{args[:max_age]} seconds have not been processed yet"


### PR DESCRIPTION
Related issue: #618