### PR TITLE
Use `yaml_tag` instead of deprecated `yaml_as`

### DIFF
--- a/lib/delayed/serialization/active_record.rb
+++ b/lib/delayed/serialization/active_record.rb
@@ -1,7 +1,7 @@
 if defined?(ActiveRecord)
   module ActiveRecord
     class Base
-      yaml_as 'tag:ruby.yaml.org,2002:ActiveRecord'
+      yaml_tag 'tag:ruby.yaml.org,2002:ActiveRecord'
 
       def self.yaml_new(klass, _tag, val)
         klass.unscoped.find(val['attributes'][klass.primary_key])

--- a/lib/delayed/syck_ext.rb
+++ b/lib/delayed/syck_ext.rb
@@ -1,5 +1,5 @@
 class Module
-  yaml_as 'tag:ruby.yaml.org,2002:module'
+  yaml_tag 'tag:ruby.yaml.org,2002:module'
 
   def self.yaml_new(_klass, _tag, val)
     val.constantize
@@ -20,7 +20,7 @@ class Module
 end
 
 class Class
-  yaml_as 'tag:ruby.yaml.org,2002:class'
+  yaml_tag 'tag:ruby.yaml.org,2002:class'
   remove_method :to_yaml if respond_to?(:to_yaml) && method(:to_yaml).owner == Class # use Module's to_yaml
 end
 


### PR DESCRIPTION
`yaml_as` is deprecated since Ruby 1.9.3.
https://github.com/ruby/ruby/commit/5b5bbdbb35098e8e2dabe7af5d31526a54dc8bbd

And it will be remove in Ruby 2.5.0.
https://github.com/ruby/ruby/commit/6d77e28763ed17f75edf3b4072701b4dbd7644bb