### PR TITLE
use prefix option to label process names

### DIFF
--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -119,6 +119,7 @@ module Delayed
     end
 
     def run_process(process_name, options = {})
+      process_name = "#{@options[:prefix]}.#{process_name}" if @options[:prefix]
       Delayed::Worker.before_fork
       Daemons.run_proc(process_name, :dir => options[:pid_dir], :dir_mode => :normal, :monitor => @monitor, :ARGV => @args) do |*_args|
         $0 = File.join(options[:prefix], process_name) if @options[:prefix]

--- a/spec/delayed/command_spec.rb
+++ b/spec/delayed/command_spec.rb
@@ -176,4 +176,18 @@ describe Delayed::Command do
       command.daemonize
     end
   end
+
+  describe 'prefix option' do
+    it 'should run processes with prefix in the process name' do
+      command = Delayed::Command.new(['--prefix=my_prefix'])
+      Daemons = double
+      expect(FileUtils).to receive(:mkdir_p).with('./tmp/pids').once
+      args = ['my_prefix.delayed_job', {:dir => './tmp/pids',
+                                        :dir_mode => :normal,
+                                        :monitor => false,
+                                        :ARGV => []}]
+      expect(Daemons).to receive(:run_proc).with(*args).once
+      command.daemonize
+    end
+  end
 end


### PR DESCRIPTION
It would be great, if delayed_job uses the prefix option to label the process names. So far, it only labels the pid files with the prefix. 

