### PR TITLE
Introduce PayloadNotFoundError (subclass of DeserializationError)

### DIFF
--- a/lib/delayed/deserialization_error.rb
+++ b/lib/delayed/deserialization_error.rb
@@ -1,4 +1,7 @@
 module Delayed
   class DeserializationError < StandardError
   end
+
+  class PayloadNotFoundError < DeserializationError
+  end
 end

--- a/lib/delayed/psych_ext.rb
+++ b/lib/delayed/psych_ext.rb
@@ -39,7 +39,7 @@ module Delayed
             begin
               klass.unscoped.find(id)
             rescue ActiveRecord::RecordNotFound => error # rubocop:disable BlockNesting
-              raise Delayed::DeserializationError, "ActiveRecord::RecordNotFound, class: #{klass}, primary key: #{id} (#{error.message})"
+              raise Delayed::PayloadNotFoundError, "ActiveRecord::RecordNotFound, class: #{klass}, primary key: #{id} (#{error.message})"
             end
           else
             result
@@ -52,7 +52,7 @@ module Delayed
           begin
             klass.unscoped.find(id)
           rescue ActiveRecord::RecordNotFound => error
-            raise Delayed::DeserializationError, "ActiveRecord::RecordNotFound, class: #{klass}, primary key: #{id} (#{error.message})"
+            raise Delayed::PayloadNotFoundError, "ActiveRecord::RecordNotFound, class: #{klass}, primary key: #{id} (#{error.message})"
           end
         when %r{^!ruby/Mongoid:(.+)$}
           klass = resolve_class(Regexp.last_match[1])
@@ -61,7 +61,7 @@ module Delayed
           begin
             klass.find(id)
           rescue Mongoid::Errors::DocumentNotFound => error
-            raise Delayed::DeserializationError, "Mongoid::Errors::DocumentNotFound, class: #{klass}, primary key: #{id} (#{error.message})"
+            raise Delayed::PayloadNotFoundError, "Mongoid::Errors::DocumentNotFound, class: #{klass}, primary key: #{id} (#{error.message})"
           end
         when %r{^!ruby/DataMapper:(.+)$}
           klass = resolve_class(Regexp.last_match[1])
@@ -71,7 +71,7 @@ module Delayed
             key_names = primary_keys.map { |p| p.name.to_s }
             klass.get!(*key_names.map { |k| payload['attributes'][k] })
           rescue DataMapper::ObjectNotFoundError => error
-            raise Delayed::DeserializationError, "DataMapper::ObjectNotFoundError, class: #{klass} (#{error.message})"
+            raise Delayed::PayloadNotFoundError, "DataMapper::ObjectNotFoundError, class: #{klass} (#{error.message})"
           end
         else
           super

--- a/lib/delayed/serialization/active_record.rb
+++ b/lib/delayed/serialization/active_record.rb
@@ -6,7 +6,7 @@ if defined?(ActiveRecord)
       def self.yaml_new(klass, _tag, val)
         klass.unscoped.find(val['attributes'][klass.primary_key])
       rescue ActiveRecord::RecordNotFound
-        raise Delayed::DeserializationError, "ActiveRecord::RecordNotFound, class: #{klass} , primary key: #{val['attributes'][klass.primary_key]}"
+        raise Delayed::PayloadNotFound, "ActiveRecord::RecordNotFound, class: #{klass} , primary key: #{val['attributes'][klass.primary_key]}"
       end
 
       def to_yaml_properties


### PR DESCRIPTION
Currently, there are two types of `DeserializationError`s:

1) The handler code itself is malformed, e.g. triggered by a `Psych::SyntaxError`

2) The payload object is not found in the database (refer to `Delayed::PsychExt` class, e.g. the below)

```
        when %r{^!ruby/ActiveRecord:(.+)$}
          klass = resolve_class(Regexp.last_match[1])
          payload = Hash[*object.children.map { |c| accept c }]
          id = payload['attributes'][klass.primary_key]
          id = id.value if defined?(ActiveRecord::Attribute) && id.is_a?(ActiveRecord::Attribute)
          begin
            klass.unscoped.find(id)
          rescue ActiveRecord::RecordNotFound => error
            raise Delayed::PayloadNotFoundError, "ActiveRecord::RecordNotFound, class: #{klass}, primary key: #{id} (#{error.message})"
          end
```

Case 1 makes sense to handle by immediately permanently failing the job, if the yaml is malformed the job will never run.

Case 2 however, there is a possibility that the job will run at a later time, as the object could appear later in the database. This is especially true for Mongoid, which is non-transactional and uses replication with some minor timelag. When triggering a delayed job (e.g. a mailer) on new object creation, the job can possibly be invoked and query a replica set member BEFORE the data has replicated, raising a Mongoid::Errors::DocumentNotFound which is re-raised as a Delayed::DeserializationError.

To give power users like myself more flexibility, I've introduced a new config `Delayed::Worker.fail_if_payload_not_found`. The default is the current behavior (immediate failure) however it can be tweaked to retry.