### PR TITLE
add hooks to surround the dj execution in the worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,10 @@ class ParanoidNewsletterJob < NewsletterJob
     emails.each { |e| NewsletterMailer.deliver_text_to_email(text, e) }
   end
 
+  def init_job_config
+    record_stat 'newsletter_job/start'
+  end
+
   def before(job)
     record_stat 'newsletter_job/start'
   end
@@ -405,6 +409,10 @@ class ParanoidNewsletterJob < NewsletterJob
 
   def failure(job)
     page_sysadmin_in_the_middle_of_the_night
+  end
+
+  def clean_job_config
+    record_stat 'newsletter_job/start'
   end
 end
 ```

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -225,12 +225,14 @@ module Delayed
     end
 
     def run(job)
+      job.hook(:init_job_config)
       job_say job, 'RUNNING'
       runtime = Benchmark.realtime do
         Timeout.timeout(max_run_time(job).to_i, WorkerTimeout) { job.invoke_job }
         job.destroy
       end
       job_say job, format('COMPLETED after %.4f', runtime)
+      job.hook(:clean_job_config)
       return true # did work
     rescue DeserializationError => error
       job_say job, "FAILED permanently with #{error.class.name}: #{error.message}", 'error'
@@ -239,6 +241,7 @@ module Delayed
       failed(job)
     rescue Exception => error # rubocop:disable RescueException
       self.class.lifecycle.run_callbacks(:error, self, job) { handle_failed_job(job, error) }
+      job.hook(:clean_job_config)
       return false # work failed
     end
 
@@ -260,6 +263,7 @@ module Delayed
       self.class.lifecycle.run_callbacks(:failure, self, job) do
         begin
           job.hook(:failure)
+          job.hook(:clean_job_config)
         rescue => error
           say "Error when running failure callback: #{error}", 'error'
           say error.backtrace.join("\n"), 'error'


### PR DESCRIPTION
Add hooks to surround the DJ execution in the worker. This will allow us to configure the environment for each individual Dj. A good use case, when we would like to tag the logs of each Dj bases on an attribute of the DJ.
