### PR TITLE
Improved reloading

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -119,6 +119,10 @@ module Delayed
       defined?(ActionDispatch::Reloader) && Rails.application.config.cache_classes == false
     end
 
+    def self.jobs_to_run?
+      Delayed::Job.respond_to?(:jobs_to_run?) && Delayed::Job.jobs_to_run?
+    end
+
     def self.delay_job?(job)
       if delay_jobs.is_a?(Proc)
         delay_jobs.arity == 1 ? delay_jobs.call(job) : delay_jobs.call
@@ -326,6 +330,9 @@ module Delayed
 
     def reload!
       return unless self.class.reload_app?
+      return unless self.class.jobs_to_run?
+
+      say "Reloading Rails App"
       if defined?(ActiveSupport::Reloader)
         Rails.application.reloader.reload!
       else


### PR DESCRIPTION
Currently the code reloads the Rails app every 5 seconds (default wait time). 
This is not necessary, as the reload only needs to happen when there are jobs to run.

I modified the code to check if there are jobs to run by adding a `jobs_to_run?` method which checks to see if the backend has implemented this method. If the method is not implemented by the backend, then the reloading will happen every 5 seconds as it used to.

If the backend has implemented the method, then reloading will only happen when there are jobs to run.
This is similar to when Rails reloads the code, only when there is a web request and not every X seconds.

I will open a PR with delayed_job_active_record to add the method there.