### PR TITLE
revert weird jruby (bug) work-around

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ rvm:
   - 2.3.7
   - 2.4.4
   - 2.5.1
-  - jruby-9.1.15.0
+  - jruby-9.1.17.0
   - jruby-head
   - ruby-head
 before_install:
@@ -26,9 +26,9 @@ matrix:
     - rvm: jruby-head
     - rvm: ruby-head
     - env: RAILS_VERSION="edge"
-    - rvm: jruby-9.1.15.0
+    - rvm: jruby-9.1.17.0
       env: RAILS_VERSION="~> 5.1.0"
-    - rvm: jruby-9.1.15.0
+    - rvm: jruby-9.1.17.0
       env: RAILS_VERSION="~> 5.2.0"
   fast_finish: true
   # legacy testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ matrix:
     - rvm: ruby-head
     - env: RAILS_VERSION="edge"
     - rvm: jruby-9.1.17.0
-      env: RAILS_VERSION="~> 5.1.0"
-    - rvm: jruby-9.1.17.0
       env: RAILS_VERSION="~> 5.2.0"
   fast_finish: true
   # legacy testing

--- a/lib/delayed/psych_ext.rb
+++ b/lib/delayed/psych_ext.rb
@@ -33,7 +33,7 @@ module Delayed
         case object.tag
         when %r{^!ruby/object}
           result = super
-          if jruby_is_seriously_borked && result.is_a?(ActiveRecord::Base)
+          if defined?(ActiveRecord::Base) && result.is_a?(ActiveRecord::Base)
             klass = result.class
             id = result[klass.primary_key]
             begin
@@ -76,13 +76,6 @@ module Delayed
         else
           super
         end
-      end
-
-      # defined? is triggering something really messed up in
-      # jruby causing both the if AND else clauses to execute,
-      # however if the check is run here, everything is fine
-      def jruby_is_seriously_borked
-        defined?(ActiveRecord::Base)
       end
 
       def resolve_class(klass_name)


### PR DESCRIPTION
this PR was initiated from looking into a 'weird' (JRuby work-around) commit: https://github.com/collectiveidea/delayed_job/commit/f37ca9e29cfd1811aefe7026134167dd10ee40b5

... which seems like its already fixed with latest JRuby 9.1 (master also seems fine) [according to CI](https://travis-ci.org/kares/delayed_job/builds/376021565)

happy to leave the work-around in if wanted, in which case this would be reduced to a CI JRuby upgrade ...