### PR TITLE
Fix warnings tickled by test suite

### DIFF
--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -24,6 +24,8 @@ module Delayed
 
       @worker_count = 1
       @monitor = false
+      @args = nil
+      @daemon_options = nil
 
       opts = OptionParser.new do |opt|
         opt.banner = "Usage: #{File.basename($PROGRAM_NAME)} [options] start|stop|restart|run"

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -2,6 +2,7 @@ require 'timeout'
 require 'active_support/dependencies'
 require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/class/attribute_accessors'
+require 'active_support/core_ext/module/redefine_method'
 require 'active_support/hash_with_indifferent_access'
 require 'active_support/core_ext/hash/indifferent_access'
 require 'logger'
@@ -19,10 +20,13 @@ module Delayed
     DEFAULT_QUEUE_ATTRIBUTES = HashWithIndifferentAccess.new.freeze
     DEFAULT_READ_AHEAD       = 5
 
-    cattr_accessor :min_priority, :max_priority, :max_attempts, :max_run_time,
-                   :default_priority, :sleep_delay, :logger, :delay_jobs, :queues,
-                   :read_ahead, :plugins, :destroy_failed_jobs, :exit_on_complete,
-                   :default_log_level
+    cattr_accessor :min_priority, :max_priority, :default_priority, :sleep_delay,
+                   :logger, :delay_jobs, :queues, :read_ahead, :plugins,
+                   :destroy_failed_jobs, :exit_on_complete, :default_log_level
+
+    class << self
+      attr_accessor :max_attempts, :max_run_time
+    end
 
     # Named queue into which jobs are enqueued by default
     cattr_accessor :default_queue_name
@@ -31,6 +35,7 @@ module Delayed
 
     # name_prefix is ignored if name is set directly
     attr_accessor :name_prefix
+    attr_writer :max_attempts, :max_run_time
 
     def self.reset
       self.default_log_level = DEFAULT_LOG_LEVEL
@@ -130,6 +135,8 @@ module Delayed
     def initialize(options = {})
       @quiet = options.key?(:quiet) ? options[:quiet] : true
       @failed_reserve_count = 0
+      @name_prefix = nil
+      @exit = nil
 
       [:min_priority, :max_priority, :sleep_delay, :read_ahead, :queues, :exit_on_complete].each do |option|
         self.class.send("#{option}=", options[option]) if options.key?(option)
@@ -145,7 +152,7 @@ module Delayed
     # safely resume working on tasks which are locked by themselves. The worker will assume that
     # it crashed before.
     def name
-      return @name unless @name.nil?
+      return @name if defined?(@name)
       "#{@name_prefix}host:#{Socket.gethostname} pid:#{Process.pid}" rescue "#{@name_prefix}pid:#{Process.pid}"
     end
 

--- a/spec/delayed/backend/test.rb
+++ b/spec/delayed/backend/test.rb
@@ -5,7 +5,6 @@ module Delayed
   module Backend
     module Test
       class Job
-        attr_accessor :id
         attr_accessor :priority
         attr_accessor :attempts
         attr_accessor :handler

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -31,9 +31,6 @@ else
 end
 ENV['RAILS_ENV'] = 'test'
 
-# Trigger AR to initialize
-ActiveRecord::Base # rubocop:disable Void
-
 module Rails
   def self.root
     '.'


### PR DESCRIPTION
Before:

```
$ bundle exec rspec -w

/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/rspec-core-3.7.1/lib/rspec/core/configuration_options.rb:171: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/rspec-core-3.7.1/lib/rspec/core/configuration_options.rb:171: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
/home/u/code/delayed_job/spec/helper.rb:35: warning: possibly useless use of :: in void context
/home/u/code/delayed_job/lib/delayed/worker.rb:288: warning: method redefined; discarding old max_attempts
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/activesupport-5.2.0/lib/active_support/core_ext/module/attribute_accessors.rb:67: warning: previous definition of max_attempts was here
/home/u/code/delayed_job/lib/delayed/worker.rb:292: warning: method redefined; discarding old max_run_time
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/activesupport-5.2.0/lib/active_support/core_ext/module/attribute_accessors.rb:67: warning: previous definition of max_run_time was here
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/activesupport-5.2.0/lib/active_support/core_ext/module/attribute_accessors.rb:67: warning: method redefined; discarding old id
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/activesupport-5.2.0/lib/active_support/core_ext/module/attribute_accessors.rb:134: warning: method redefined; discarding old id=
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/abstract/schema_statements.rb:495: warning: in `drop_table': the last argument was passed as a single Hash
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/abstract/schema_statements.rb:308: warning: although a splat keyword arguments here

Randomized with seed 47045
...................../home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
...../home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:938: warning: statement not reached
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:963: warning: statement not reached
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:991: warning: mismatched indentations at 'when' with 'case' at 990
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:994: warning: mismatched indentations at 'when' with 'case' at 990
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:1008: warning: mismatched indentations at 'when' with 'case' at 990
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:1011: warning: mismatched indentations at 'when' with 'case' at 990
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:1034: warning: mismatched indentations at 'end' with 'while' at 725
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:1035: warning: mismatched indentations at 'end' with 'begin' at 716
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:717: warning: assigned but unused variable - testEof
......................../home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
../home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
............../home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
......................../home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:203: warning: instance variable @exit not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:203: warning: instance variable @exit not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:203: warning: instance variable @exit not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:203: warning: instance variable @exit not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:203: warning: instance variable @exit not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:203: warning: instance variable @exit not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
........../home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
...../home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:203: warning: instance variable @exit not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
../home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
../home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
../home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
./home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
/home/u/code/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
../home/u/code/delayed_job/lib/delayed/command.rb:84: warning: instance variable @daemon_options not initialized
./home/u/code/delayed_job/lib/delayed/command.rb:84: warning: instance variable @daemon_options not initialized
./home/u/code/delayed_job/lib/delayed/command.rb:84: warning: instance variable @daemon_options not initialized
./home/u/code/delayed_job/lib/delayed/command.rb:84: warning: instance variable @daemon_options not initialized
./home/u/code/delayed_job/lib/delayed/command.rb:84: warning: instance variable @daemon_options not initialized
./home/u/code/delayed_job/lib/delayed/command.rb:84: warning: instance variable @daemon_options not initialized
./home/u/code/delayed_job/lib/delayed/command.rb:84: warning: instance variable @daemon_options not initialized
./home/u/code/delayed_job/lib/delayed/command.rb:84: warning: instance variable @daemon_options not initialized
./home/u/code/delayed_job/lib/delayed/command.rb:84: warning: instance variable @daemon_options not initialized
./home/u/code/delayed_job/lib/delayed/command.rb:84: warning: instance variable @daemon_options not initialized
./home/u/code/delayed_job/lib/delayed/command.rb:84: warning: instance variable @daemon_options not initialized
./home/u/code/delayed_job/lib/delayed/command.rb:84: warning: instance variable @daemon_options not initialized
./home/u/code/delayed_job/lib/delayed/command.rb:84: warning: instance variable @daemon_options not initialized
/home/u/code/delayed_job/lib/delayed/command.rb:84: warning: instance variable @daemon_options not initialized
./home/u/code/delayed_job/lib/delayed/command.rb:84: warning: instance variable @daemon_options not initialized
./home/u/code/delayed_job/lib/delayed/command.rb:84: warning: instance variable @daemon_options not initialized
..................

Finished in 1.44 seconds (files took 0.77233 seconds to load)
173 examples, 0 failures
```

After: 

```
$ bundle exec rspec -w

/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/rspec-core-3.7.1/lib/rspec/core/configuration_options.rb:171: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/rspec-core-3.7.1/lib/rspec/core/configuration_options.rb:171: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/abstract/schema_statements.rb:495: warning: in `drop_table': the last argument was passed as a single Hash
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/abstract/schema_statements.rb:308: warning: although a splat keyword arguments here

Randomized with seed 61903
........................................................................................................./home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:938: warning: statement not reached
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:963: warning: statement not reached
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:991: warning: mismatched indentations at 'when' with 'case' at 990
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:994: warning: mismatched indentations at 'when' with 'case' at 990
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:1008: warning: mismatched indentations at 'when' with 'case' at 990
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:1011: warning: mismatched indentations at 'when' with 'case' at 990
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:1034: warning: mismatched indentations at 'end' with 'while' at 725
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:1035: warning: mismatched indentations at 'end' with 'begin' at 716
/home/u/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:717: warning: assigned but unused variable - testEof
....................................................................

Finished in 1.45 seconds (files took 0.77168 seconds to load)
173 examples, 0 failures
```
Issue came up in https://github.com/rails/rails/pull/33257, but I thought I may as well be thorough.