### PR TITLE
Fixes bug when loading railtie within a rails app with action-mailer disabled

### DIFF
--- a/lib/delayed/railtie.rb
+++ b/lib/delayed/railtie.rb
@@ -5,7 +5,9 @@ module Delayed
   class Railtie < Rails::Railtie
     initializer :after_initialize do
       ActiveSupport.on_load(:action_mailer) do
-        ActionMailer::Base.extend(Delayed::DelayMail)
+        if defined?(Delayed::DelayMail)
+          ActionMailer::Base.extend(Delayed::DelayMail)
+        end
       end
 
       Delayed::Worker.logger ||= if defined?(Rails)


### PR DESCRIPTION
With a `config/application.rb` like so;

```ruby
# NOTE: only require rails frameworks we need for an API
# require 'rails/all'
require 'rails'
require 'active_model/railtie'
require 'active_record/railtie'
require 'action_controller/railtie'

# NOTE: frameworks we are not including (see railties/all.rb)
# require 'action_mailer/railtie'
# require 'action_view/railtie'
# require 'sprockets/railtie'
# require 'rails/test_unit/railtie'
```

Booting the app / running tests results in

```
uninitialized constant Delayed::DelayMail (NameError)
/gems/ruby-2.2.5/gems/delayed_job-4.1.5/lib/delayed/railtie.rb:9:in `block (2 levels) in <class:Railtie>'
/gems/ruby-2.2.5/gems/activesupport-4.0.13/lib/active_support/lazy_load_hooks.rb:38:in `instance_eval'
/gems/ruby-2.2.5/gems/activesupport-4.0.13/lib/active_support/lazy_load_hooks.rb:38:in `execute_hook'
/gems/ruby-2.2.5/gems/activesupport-4.0.13/lib/active_support/lazy_load_hooks.rb:28:in `block in on_load'
/gems/ruby-2.2.5/gems/activesupport-4.0.13/lib/active_support/lazy_load_hooks.rb:27:in `each'
/gems/ruby-2.2.5/gems/activesupport-4.0.13/lib/active_support/lazy_load_hooks.rb:27:in `on_load'
/gems/ruby-2.2.5/gems/delayed_job-4.1.5/lib/delayed/railtie.rb:8:in `block in <class:Railtie>'
/gems/ruby-2.2.5/gems/railties-4.0.13/lib/rails/initializable.rb:30:in `instance_exec'
/gems/ruby-2.2.5/gems/railties-4.0.13/lib/rails/initializable.rb:30:in `run'
/gems/ruby-2.2.5/gems/railties-4.0.13/lib/rails/initializable.rb:55:in `block in run_initializers'
/rubies/ruby-2.2.5/lib/ruby/2.2.0/tsort.rb:226:in `block in tsort_each'
/rubies/ruby-2.2.5/lib/ruby/2.2.0/tsort.rb:348:in `block (2 levels) in each_strongly_connected_component'
/rubies/ruby-2.2.5/lib/ruby/2.2.0/tsort.rb:429:in `each_strongly_connected_component_from'
/rubies/ruby-2.2.5/lib/ruby/2.2.0/tsort.rb:347:in `block in each_strongly_connected_component'
/rubies/ruby-2.2.5/lib/ruby/2.2.0/tsort.rb:345:in `each'
/rubies/ruby-2.2.5/lib/ruby/2.2.0/tsort.rb:345:in `call'
/rubies/ruby-2.2.5/lib/ruby/2.2.0/tsort.rb:345:in `each_strongly_connected_component'
/rubies/ruby-2.2.5/lib/ruby/2.2.0/tsort.rb:224:in `tsort_each'
/rubies/ruby-2.2.5/lib/ruby/2.2.0/tsort.rb:203:in `tsort_each'
/gems/ruby-2.2.5/gems/railties-4.0.13/lib/rails/initializable.rb:54:in `run_initializers'
/gems/ruby-2.2.5/gems/railties-4.0.13/lib/rails/application.rb:215:in `initialize!'
/gems/ruby-2.2.5/gems/cucumber-rails-1.4.5/lib/cucumber/rails/application.rb:15:in `initialize!'
/gems/ruby-2.2.5/gems/railties-4.0.13/lib/rails/railtie/configurable.rb:30:in `method_missing'
/app/config/environment.rb:5:in `<top (required)>'
/gems/ruby-2.2.5/gems/cucumber-rails-1.4.5/lib/cucumber/rails.rb:7:in `require'
/gems/ruby-2.2.5/gems/cucumber-rails-1.4.5/lib/cucumber/rails.rb:7:in `<top (required)>'
/app/features/support/env.rb:7:in `require'
/app/features/support/env.rb:7:in `<top (required)>'
/gems/ruby-2.2.5/gems/cucumber-2.4.0/lib/cucumber/rb_support/rb_language.rb:96:in `load'
/gems/ruby-2.2.5/gems/cucumber-2.4.0/lib/cucumber/rb_support/rb_language.rb:96:in `load_code_file'
/gems/ruby-2.2.5/gems/cucumber-2.4.0/lib/cucumber/runtime/support_code.rb:142:in `load_file'
/gems/ruby-2.2.5/gems/cucumber-2.4.0/lib/cucumber/runtime/support_code.rb:84:in `block in load_files!'
/gems/ruby-2.2.5/gems/cucumber-2.4.0/lib/cucumber/runtime/support_code.rb:83:in `each'
/gems/ruby-2.2.5/gems/cucumber-2.4.0/lib/cucumber/runtime/support_code.rb:83:in `load_files!'
/gems/ruby-2.2.5/gems/cucumber-2.4.0/lib/cucumber/runtime.rb:253:in `load_step_definitions'
/gems/ruby-2.2.5/gems/cucumber-2.4.0/lib/cucumber/runtime.rb:61:in `run!'
/gems/ruby-2.2.5/gems/cucumber-2.4.0/lib/cucumber/cli/main.rb:32:in `execute!'
/gems/ruby-2.2.5/gems/cucumber-2.4.0/bin/cucumber:8:in `<top (required)>'
/gems/ruby-2.2.5/bin/cucumber:23:in `load'
/gems/ruby-2.2.5/bin/cucumber:23:in `<top (required)>'
/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/bundler/cli/exec.rb:75:in `load'
/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/bundler/cli/exec.rb:75:in `kernel_load'
/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/bundler/cli/exec.rb:28:in `run'
/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/bundler/cli.rb:424:in `exec'
/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/bundler/cli.rb:27:in `dispatch'
/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/bundler/cli.rb:18:in `start'
/rubies/ruby-2.2.5/bin/bundle:30:in `block in <main>'
/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/bundler/friendly_errors.rb:122:in `with_friendly_errors'
/rubies/ruby-2.2.5/bin/bundle:22:in `<main>'
```
