### PR TITLE
Enhancement to allow jobs to be "versioned"

### DIFF
--- a/lib/delayed/backend/job_preparer.rb
+++ b/lib/delayed/backend/job_preparer.rb
@@ -12,6 +12,7 @@ module Delayed
         set_payload
         set_queue_name
         set_priority
+        set_version
         handle_deprecation
         options
       end
@@ -33,6 +34,10 @@ module Delayed
       def set_priority
         queue_attribute = Delayed::Worker.queue_attributes[options[:queue]]
         options[:priority] ||= (queue_attribute && queue_attribute[:priority]) || Delayed::Worker.default_priority
+      end
+
+      def set_version
+        options[:version] ||= Delayed::Worker.current_version
       end
 
       def handle_deprecation

--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -6,7 +6,7 @@ shared_examples_for 'a delayed_job backend' do
   let(:worker) { Delayed::Worker.new }
 
   def create_job(opts = {})
-    described_class.create({ :payload_object => SimpleJob.new, :version => Delayed::Worker.current_version }.merge(opts))
+    described_class.create({:payload_object => SimpleJob.new, :version => Delayed::Worker.current_version}.merge(opts))
   end
 
   before do
@@ -270,12 +270,12 @@ shared_examples_for 'a delayed_job backend' do
     end
 
     it 'reserves jobs with configured version' do
-      job = create_job version: '123'
+      job = create_job :version => '123'
       expect(described_class.reserve(worker)).to eq(job)
     end
 
     it 'does not reserve jobs with version other than the configured version' do
-      job = create_job version: '456'
+      job = create_job :version => '456'
       expect(job.version).to eq('456')
       expect(described_class.reserve(worker)).to be_nil
     end

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -27,6 +27,9 @@ module Delayed
     # Named queue into which jobs are enqueued by default
     cattr_accessor :default_queue_name
 
+    # Version to which jobs created by this worker will be scoped by default
+    cattr_accessor :current_version
+
     cattr_reader :backend, :queue_attributes
 
     # name_prefix is ignored if name is set directly

--- a/spec/delayed/backend/test.rb
+++ b/spec/delayed/backend/test.rb
@@ -15,6 +15,7 @@ module Delayed
         attr_accessor :locked_by
         attr_accessor :failed_at
         attr_accessor :queue
+        attr_accessor :version
 
         include Delayed::Backend::Base
 
@@ -67,6 +68,7 @@ module Delayed
           jobs.select! { |j| j.priority <= Worker.max_priority } if Worker.max_priority
           jobs.select! { |j| j.priority >= Worker.min_priority } if Worker.min_priority
           jobs.select! { |j| Worker.queues.include?(j.queue) } if Worker.queues.any?
+          jobs.select! { |j| j.version == Worker.current_version }
           jobs.sort_by! { |j| [j.priority, j.run_at] }[0..limit - 1]
         end
 


### PR DESCRIPTION
Code in job handlers can become out of date when you restart workers after a deploy.

Example: a method used in a job handler has been renamed as part of a deploy, the worker restarts (loading the new code) and tries to run the job, resulting in a NoMethodError.

Other times when this might be a problem: deploying changes that affect marshalling, Ruby / Rails major updates.

This PR adds the notion of job "version".

New jobs are given the version specified in `Delayed::Worker.current_version`.

Similarly, workers scope jobs to the version specified in `Delayed::Worker.current_version`.

Now, if deploying code you think might affect already-queued jobs, you can bump the version with `Delayed::Worker.current_version = "whatever"`

Post deploy, newly created jobs are not available to workers until they restart.

When you restart a worker, jobs created with the old version will no longer be visible to the worker and so will not be invoked by it.

Ideally you'd have multiple workers, so restarting "worker A" with the new version leaves "worker B" to pick up the remaining jobs (until it restarts)

Alternatively, jobs created with the old version will just sit in the queue, giving you the opportunity to handle them manually in the console.

I've made the necessary changes to `delayed_job_active_record` in another PR