### PR TITLE
Replace REMOVED with FAILED in log message

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -251,7 +251,7 @@ module Delayed
         job.unlock
         job.save!
       else
-        job_say job, "REMOVED permanently because of #{job.attempts} consecutive failures", 'error'
+        job_say job, "FAILED permanently because of #{job.attempts} consecutive failures", 'error'
         failed(job)
       end
     end


### PR DESCRIPTION
The term REMOVED was misleading when `destroy_failed_jobs = false`.

The term FAILED is not misleading, and is also [used elsewhere in similar contexts](https://github.com/collectiveidea/delayed_job/compare/master...dan-jensen:master#diff-70ead5838f9d70eb6391b0b682b035fdR236), so is more conventional.