### PR TITLE
Update upper dependency for activesupport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ rvm:
   - 2.3.7
   - 2.4.4
   - 2.5.3
+  - 2.6.1
   - jruby-9.1.15.0
   - jruby-head
   - ruby-head
@@ -53,5 +54,7 @@ matrix:
     - rvm: 2.2.10
       env: RAILS_VERSION="edge"
     - rvm: 2.3.7
+      env: RAILS_VERSION="edge"
+    - rvm: 2.4.4
       env: RAILS_VERSION="edge"
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,15 @@ env:
     - JRUBY_OPTS="$JRUBY_OPTS --debug"
   matrix:
     - RAILS_VERSION="~> 4.2.0"
-    - RAILS_VERSION="~> 5.0.0"
     - RAILS_VERSION="~> 5.1.0"
+    - RAILS_VERSION="~> 5.2.0"
     - RAILS_VERSION="edge"
 rvm:
   - 2.1.10
   - 2.2.7
   - 2.3.4
   - 2.4.1
+  - 2.5.3
   - jruby-9.1.8.0
   - jruby-head
   - rbx-2
@@ -45,9 +46,13 @@ matrix:
       env: RAILS_VERSION="~> 4.1.0"
   exclude:
     - rvm: 2.1.10
-      env: RAILS_VERSION="~> 5.0.0"
-    - rvm: 2.1.10
       env: RAILS_VERSION="~> 5.1.0"
     - rvm: 2.1.10
+      env: RAILS_VERSION="~> 5.2.0"
+    - rvm: 2.1.10
+      env: RAILS_VERSION="edge"
+    - rvm: 2.2.7
+      env: RAILS_VERSION="edge"
+    - rvm: 2.3.4
       env: RAILS_VERSION="edge"
 sudo: false

--- a/delayed_job.gemspec
+++ b/delayed_job.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'activesupport', ['>= 3.0', '< 5.2']
+  spec.add_dependency 'activesupport', ['>= 3.0', '< 6.1']
   spec.authors        = ['Brandon Keepers', 'Brian Ryckbost', 'Chris Gaffney', 'David Genord II', 'Erik Michaels-Ober', 'Matt Griffin', 'Steve Richert', 'Tobias Lütke']
   spec.description    = 'Delayed_job (or DJ) encapsulates the common pattern of asynchronously executing longer tasks in the background. It is a direct extraction from Shopify where the job table is responsible for a multitude of core tasks.'
   spec.email          = ['brian@collectiveidea.com']

--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -133,7 +133,7 @@ module Delayed
       end
 
       def fail!
-        update_attributes(:failed_at => self.class.db_time_now)
+        update!(:failed_at => self.class.db_time_now)
       end
 
     protected

--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -523,7 +523,7 @@ shared_examples_for 'a delayed_job backend' do
       it 'reloads changed attributes' do
         story = Story.create(:text => 'hello')
         job = story.delay.tell
-        story.update_attributes :text => 'goodbye'
+        story.update :text => 'goodbye'
         expect(job.reload.payload_object.object.text).to eq('goodbye')
       end
 

--- a/spec/delayed/backend/test.rb
+++ b/spec/delayed/backend/test.rb
@@ -87,7 +87,7 @@ module Delayed
           Time.current
         end
 
-        def update_attributes(attrs = {})
+        def update(attrs = {})
           attrs.each { |k, v| send(:"#{k}=", v) }
           save
         end


### PR DESCRIPTION
We are trying to test our application on rails 6.0.0.alpha but we can't install this because of the version lock
Probably this will be helpful that we can try and report any issues with edge rails