### PR TITLE
Change hook names to be more delayed-job specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .rvmrc
 /coverage
 Gemfile.lock
+/vendor

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ You can define hooks on your job that will be called at different stages in the 
 
 ```ruby
 class ParanoidNewsletterJob < NewsletterJob
-  def enqueue(job)
+  def on_job_enqueue(job)
     record_stat 'newsletter_job/enqueue'
   end
 
@@ -387,23 +387,23 @@ class ParanoidNewsletterJob < NewsletterJob
     emails.each { |e| NewsletterMailer.deliver_text_to_email(text, e) }
   end
 
-  def before(job)
+  def before_job_run(job)
     record_stat 'newsletter_job/start'
   end
 
-  def after(job)
+  def after_job_run(job)
     record_stat 'newsletter_job/after'
   end
 
-  def success(job)
+  def on_job_success(job)
     record_stat 'newsletter_job/success'
   end
 
-  def error(job, exception)
+  def on_job_error(job, exception)
     Airbrake.notify(exception)
   end
 
-  def failure(job)
+  def on_job_failure(job)
     page_sysadmin_in_the_middle_of_the_night
   end
 end

--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -15,7 +15,7 @@ module Delayed
         def enqueue_job(options)
           new(options).tap do |job|
             Delayed::Worker.lifecycle.run_callbacks(:enqueue, job) do
-              job.hook(:enqueue)
+              job.hook(:on_job_enqueue)
               Delayed::Worker.delay_job?(job) ? job.save : job.invoke_job
             end
           end
@@ -77,14 +77,14 @@ module Delayed
       def invoke_job
         Delayed::Worker.lifecycle.run_callbacks(:invoke_job, self) do
           begin
-            hook :before
+            hook :before_job_run
             payload_object.perform
-            hook :success
+            hook :on_job_success
           rescue Exception => e # rubocop:disable RescueException
-            hook :error, e
+            hook :on_job_error, e
             raise e
           ensure
-            hook :after
+            hook :after_job_run
           end
         end
       end

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -259,7 +259,7 @@ module Delayed
     def failed(job)
       self.class.lifecycle.run_callbacks(:failure, self, job) do
         begin
-          job.hook(:failure)
+          job.hook(:on_job_failure)
         rescue => error
           say "Error when running failure callback: #{error}", 'error'
           say error.backtrace.join("\n"), 'error'

--- a/spec/performable_method_spec.rb
+++ b/spec/performable_method_spec.rb
@@ -47,7 +47,7 @@ describe Delayed::PerformableMethod do
   end
 
   describe 'hooks' do
-    %w[before after success].each do |hook|
+    %w[before_job_run after_job_run on_job_success].each do |hook|
       it "delegates #{hook} hook to object" do
         story = Story.create
         job = story.delay.tell
@@ -57,23 +57,23 @@ describe Delayed::PerformableMethod do
       end
     end
 
-    it 'delegates enqueue hook to object' do
+    it 'delegates on_job_enqueue hook to object' do
       story = Story.create
-      expect(story).to receive(:enqueue).with(an_instance_of(Delayed::Job))
+      expect(story).to receive(:on_job_enqueue).with(an_instance_of(Delayed::Job))
       story.delay.tell
     end
 
-    it 'delegates error hook to object' do
+    it 'delegates on_job_error hook to object' do
       story = Story.create
-      expect(story).to receive(:error).with(an_instance_of(Delayed::Job), an_instance_of(RuntimeError))
+      expect(story).to receive(:on_job_error).with(an_instance_of(Delayed::Job), an_instance_of(RuntimeError))
       expect(story).to receive(:tell).and_raise(RuntimeError)
       expect { story.delay.tell.invoke_job }.to raise_error(RuntimeError)
     end
 
-    it 'delegates failure hook to object' do
+    it 'delegates on_job_failure hook to object' do
       method = Delayed::PerformableMethod.new('object', :size, [])
-      expect(method.object).to receive(:failure)
-      method.failure
+      expect(method.object).to receive(:on_job_failure)
+      method.on_job_failure
     end
 
     context 'with delay_job == false' do
@@ -85,7 +85,7 @@ describe Delayed::PerformableMethod do
         Delayed::Worker.delay_jobs = true
       end
 
-      %w[before after success].each do |hook|
+      %w[before_job_run after_job_run on_job_success].each do |hook|
         it "delegates #{hook} hook to object" do
           story = Story.create
           expect(story).to receive(hook).with(an_instance_of(Delayed::Job))
@@ -95,7 +95,7 @@ describe Delayed::PerformableMethod do
 
       it 'delegates error hook to object' do
         story = Story.create
-        expect(story).to receive(:error).with(an_instance_of(Delayed::Job), an_instance_of(RuntimeError))
+        expect(story).to receive(:on_job_error).with(an_instance_of(Delayed::Job), an_instance_of(RuntimeError))
         expect(story).to receive(:tell).and_raise(RuntimeError)
         expect { story.delay.tell }.to raise_error(RuntimeError)
       end

--- a/spec/sample_jobs.rb
+++ b/spec/sample_jobs.rb
@@ -53,7 +53,7 @@ class OnPermanentFailureJob < SimpleJob
     @raise_error = false
   end
 
-  def failure
+  def on_job_failure
     raise 'did not work' if @raise_error
   end
 
@@ -75,37 +75,37 @@ end
 class CallbackJob
   cattr_accessor :messages
 
-  def enqueue(_job)
-    self.class.messages << 'enqueue'
+  def on_job_enqueue(_job)
+    self.class.messages << 'on_job_enqueue'
   end
 
-  def before(_job)
-    self.class.messages << 'before'
+  def before_job_run(_job)
+    self.class.messages << 'before_job_run'
   end
 
   def perform
     self.class.messages << 'perform'
   end
 
-  def after(_job)
-    self.class.messages << 'after'
+  def after_job_run(_job)
+    self.class.messages << 'after_job_run'
   end
 
-  def success(_job)
-    self.class.messages << 'success'
+  def on_job_success(_job)
+    self.class.messages << 'on_job_success'
   end
 
-  def error(_job, error)
-    self.class.messages << "error: #{error.class}"
+  def on_job_error(_job, error)
+    self.class.messages << "on_job_error: #{error.class}"
   end
 
-  def failure(_job)
-    self.class.messages << 'failure'
+  def on_job_failure(_job)
+    self.class.messages << 'on_job_failure'
   end
 end
 
 class EnqueueJobMod < SimpleJob
-  def enqueue(job)
+  def on_job_enqueue(job)
     job.run_at = 20.minutes.from_now
   end
 end


### PR DESCRIPTION
This aims to change the delayed job hooks to have more specific names to avoid collisions. Because of `performable_method`, many objects can be turned into delayed job payload objects. If those objects happen to define methods with names like "before",  "after", "error", or "success", those methods will be called by the job runner. This can cause surprising bugs and behaviors. (A similar problem is mentioned in this pr https://github.com/collectiveidea/delayed_job/pull/943)

This aims to change the names of those methods to be more specific to running delayed jobs to make them harder to collide with accidentally. 

This is a breaking change, so we could also do work to phase this change in more slowly if it's desirable (deprecate hooks with the old names, run new or old hook name -- whichever is present -- and then remove the old hook names in a following version)