### PR TITLE
Relax Rails dependency for 6.0.0.beta1

### DIFF
--- a/delayed_job.gemspec
+++ b/delayed_job.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'activesupport', ['>= 3.0', '< 5.3']
+  spec.add_dependency 'activesupport', ['>= 3.0', '< 6.0']
   spec.authors        = ['Brandon Keepers', 'Brian Ryckbost', 'Chris Gaffney', 'David Genord II', 'Erik Michaels-Ober', 'Matt Griffin', 'Steve Richert', 'Tobias Lütke']
   spec.description    = 'Delayed_job (or DJ) encapsulates the common pattern of asynchronously executing longer tasks in the background. It is a direct extraction from Shopify where the job table is responsible for a multitude of core tasks.'
   spec.email          = ['brian@collectiveidea.com']

--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -523,7 +523,7 @@ shared_examples_for 'a delayed_job backend' do
       it 'reloads changed attributes' do
         story = Story.create(:text => 'hello')
         job = story.delay.tell
-        story.update_attributes :text => 'goodbye'
+        story.update :text => 'goodbye'
         expect(job.reload.payload_object.object.text).to eq('goodbye')
       end
 


### PR DESCRIPTION
When attempting to upgrade my DJ-using application to Rails 6.0.0.beta1, I saw this issue:

```
Bundler could not find compatible versions for gem "activesupport":
  In Gemfile:
    delayed_job_mongoid was resolved to 2.3.0, which depends on
      delayed_job (>= 3.0, < 5) was resolved to 4.1.5, which depends on
        activesupport (>= 3.0, < 5.3)
```

In order to be able to use Rails 6.0.0.beta1 with Rails applications that also use DJ, I think DJ's Rails version should be relaxed slightly to allow for this.

I was also considering removing edge rails versions from the "allowed failures" of the testing matrix, but I figured you might have a good reason to leave them in there, so I've left them as-is for now.