### PR TITLE
Eliminate warnings

### DIFF
--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -450,7 +450,7 @@ shared_examples_for 'a delayed_job backend' do
     end
 
     it 'results in a default run time when not defined' do
-      expect(worker.max_run_time(@job)).to eq(Delayed::Worker::DEFAULT_MAX_RUN_TIME)
+      expect(worker.max_run_time_of(@job)).to eq(Delayed::Worker::DEFAULT_MAX_RUN_TIME)
     end
 
     it 'uses the max_run_time value on the payload when defined' do
@@ -460,12 +460,12 @@ shared_examples_for 'a delayed_job backend' do
 
     it 'results in an overridden run time when defined' do
       expect(@job.payload_object).to receive(:max_run_time).and_return(45.minutes)
-      expect(worker.max_run_time(@job)).to eq(45.minutes)
+      expect(worker.max_run_time_of(@job)).to eq(45.minutes)
     end
 
     it 'job set max_run_time can not exceed default max run time' do
       expect(@job.payload_object).to receive(:max_run_time).and_return(Delayed::Worker::DEFAULT_MAX_RUN_TIME + 60)
-      expect(worker.max_run_time(@job)).to eq(Delayed::Worker::DEFAULT_MAX_RUN_TIME)
+      expect(worker.max_run_time_of(@job)).to eq(Delayed::Worker::DEFAULT_MAX_RUN_TIME)
     end
   end
 

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -130,6 +130,9 @@ module Delayed
     def initialize(options = {})
       @quiet = options.key?(:quiet) ? options[:quiet] : true
       @failed_reserve_count = 0
+      @name = nil
+      @name_prefix = nil
+      @exit = nil
 
       [:min_priority, :max_priority, :sleep_delay, :read_ahead, :queues, :exit_on_complete].each do |option|
         self.class.send("#{option}=", options[option]) if options.key?(option)

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -230,7 +230,7 @@ module Delayed
     def run(job)
       job_say job, 'RUNNING'
       runtime = Benchmark.realtime do
-        Timeout.timeout(max_run_time(job).to_i, WorkerTimeout) { job.invoke_job }
+        Timeout.timeout(max_run_time_of(job).to_i, WorkerTimeout) { job.invoke_job }
         job.destroy
       end
       job_say job, format('COMPLETED after %.4f', runtime)
@@ -248,7 +248,7 @@ module Delayed
     # Reschedule the job in the future (when a job fails).
     # Uses an exponential scale depending on the number of failed attempts.
     def reschedule(job, time = nil)
-      if (job.attempts += 1) < max_attempts(job)
+      if (job.attempts += 1) < max_attempts_of(job)
         time ||= job.reschedule_at
         job.run_at = time
         job.unlock
@@ -288,11 +288,11 @@ module Delayed
       logger.send(level, "#{Time.now.strftime('%FT%T%z')}: #{text}")
     end
 
-    def max_attempts(job)
+    def max_attempts_of(job)
       job.max_attempts || self.class.max_attempts
     end
 
-    def max_run_time(job)
+    def max_run_time_of(job)
       job.max_run_time || self.class.max_run_time
     end
 


### PR DESCRIPTION
This change eliminates warnings that occur when [running Rails Active Job tests](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#for-a-particular-component).

```
cd rails/activejob
bundle exec rake test:delayed_job
REDACTED/delayed_job/lib/delayed/worker.rb:291: warning: method redefined; discarding old max_attempts
REDACTED/rails/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb:64: warning: previous definition of max_attempts was here
REDACTED/delayed_job/lib/delayed/worker.rb:295: warning: method redefined; discarding old max_run_time
REDACTED/rails/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb:64: warning: previous definition of max_run_time was here
REDACTED/gems/ruby-2.5.3/gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:21: warning: loading in progress, circular require considered harmful - REDACTED/delayed_job/lib/delayed_job.rb
```
and
```
cd rails/activejob
bundle exec rake test:integration:delayed_job
REDACTED/delayed_job/lib/delayed/worker.rb:148: warning: instance variable @name not initialized
REDACTED/delayed_job/lib/delayed/worker.rb:149: warning: instance variable @name_prefix not initialized
REDACTED/delayed_job/lib/delayed/worker.rb:203: warning: instance variable @exit not initialized
```