### PR TITLE
Use modern SVG alternatives of PNG badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ you're reading the documentation for the master branch.
 
 Delayed::Job
 ============
-[![Gem Version](https://badge.fury.io/rb/delayed_job.png)][gem]
-[![Build Status](https://travis-ci.org/collectiveidea/delayed_job.png?branch=master)][travis]
-[![Code Climate](https://codeclimate.com/github/collectiveidea/delayed_job.png)][codeclimate]
-[![Coverage Status](https://coveralls.io/repos/collectiveidea/delayed_job/badge.png?branch=master)][coveralls]
+[![Gem Version](https://badge.fury.io/rb/delayed_job.svg)][gem]
+[![Build Status](https://travis-ci.org/collectiveidea/delayed_job.svg?branch=master)][travis]
+[![Code Climate](https://codeclimate.com/github/collectiveidea/delayed_job.svg)][codeclimate]
+[![Coverage Status](https://coveralls.io/repos/collectiveidea/delayed_job/badge.svg?branch=master)][coveralls]
 
 [gem]: https://rubygems.org/gems/delayed_job
 [travis]: https://travis-ci.org/collectiveidea/delayed_job


### PR DESCRIPTION
These are soon to be deprecated and render very poorly on most high density displays.

Here's a visual diff from a 2015 Retina MacBook Pro: 
![image](https://user-images.githubusercontent.com/65950/52588759-375efa00-2e0b-11e9-9c0d-d7f93a1247e4.png)
