### PR TITLE
Properly initialize ActionMailer outside railties

### DIFF
--- a/lib/delayed/railtie.rb
+++ b/lib/delayed/railtie.rb
@@ -4,10 +4,6 @@ require 'rails'
 module Delayed
   class Railtie < Rails::Railtie
     initializer :after_initialize do
-      ActiveSupport.on_load(:action_mailer) do
-        ActionMailer::Base.extend(Delayed::DelayMail)
-      end
-
       Delayed::Worker.logger ||= if defined?(Rails)
         Rails.logger
       elsif defined?(RAILS_DEFAULT_LOGGER)

--- a/lib/delayed_job.rb
+++ b/lib/delayed_job.rb
@@ -3,12 +3,6 @@ require 'delayed/compatibility'
 require 'delayed/exceptions'
 require 'delayed/message_sending'
 require 'delayed/performable_method'
-
-if defined?(ActionMailer)
-  require 'action_mailer/version'
-  require 'delayed/performable_mailer'
-end
-
 require 'delayed/yaml_ext'
 require 'delayed/lifecycle'
 require 'delayed/plugin'
@@ -18,6 +12,11 @@ require 'delayed/backend/job_preparer'
 require 'delayed/worker'
 require 'delayed/deserialization_error'
 require 'delayed/railtie' if defined?(Rails::Railtie)
+
+ActiveSupport.on_load(:action_mailer) do
+  require 'delayed/performable_mailer'
+  ActionMailer::Base.extend(Delayed::DelayMail)
+end
 
 Object.send(:include, Delayed::MessageSending)
 Module.send(:include, Delayed::MessageSendingClassMethods)

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -14,7 +14,6 @@ require 'logger'
 require 'rspec'
 
 require 'action_mailer'
-require 'active_support/dependencies'
 require 'active_record'
 
 require 'delayed_job'
@@ -44,9 +43,6 @@ Delayed::Worker.backend = :test
 
 # Add this directory so the ActiveSupport autoloading works
 ActiveSupport::Dependencies.autoload_paths << File.dirname(__FILE__)
-
-# Add this to simulate Railtie initializer being executed
-ActionMailer::Base.extend(Delayed::DelayMail)
 
 # Used to test interactions between DJ and an ORM
 ActiveRecord::Base.establish_connection :adapter => 'sqlite3', :database => ':memory:'

--- a/spec/performable_mailer_spec.rb
+++ b/spec/performable_mailer_spec.rb
@@ -1,6 +1,5 @@
 require 'helper'
 
-require 'action_mailer'
 class MyMailer < ActionMailer::Base
   def signup(email)
     mail :to => email, :subject => 'Delaying Emails', :from => 'delayedjob@example.com', :body => 'Delaying Emails Body'


### PR DESCRIPTION
The divided load was triggering errors when encountering an unexpected load order. This allows the dependencies to properly load in any configuration.