### PR TITLE
Suggestion about way fixed bug #1080 

### DIFF
--- a/spec/delayed/command_spec.rb
+++ b/spec/delayed/command_spec.rb
@@ -162,13 +162,13 @@ describe Delayed::Command do
       expect(FileUtils).to receive(:mkdir_p).with('./tmp/pids').once
 
       [
-        ['delayed_job.0', {:quiet => true, :pid_dir => './tmp/pids', :log_dir => './log', :queues => []}],
-        ['delayed_job.1', {:quiet => true, :pid_dir => './tmp/pids', :log_dir => './log', :queues => ['test_queue']}],
-        ['delayed_job.2', {:quiet => true, :pid_dir => './tmp/pids', :log_dir => './log', :queues => ['test_queue']}],
-        ['delayed_job.3', {:quiet => true, :pid_dir => './tmp/pids', :log_dir => './log', :queues => ['test_queue']}],
-        ['delayed_job.4', {:quiet => true, :pid_dir => './tmp/pids', :log_dir => './log', :queues => ['test_queue']}],
-        ['delayed_job.5', {:quiet => true, :pid_dir => './tmp/pids', :log_dir => './log', :queues => %w[mailers misc]}],
-        ['delayed_job.6', {:quiet => true, :pid_dir => './tmp/pids', :log_dir => './log', :queues => %w[mailers misc]}]
+        ['delayed_job.0', {:quiet => true, :pid_delimiter => '.', :pid_dir => './tmp/pids', :log_dir => './log', :queues => []}],
+        ['delayed_job.1', {:quiet => true, :pid_delimiter => '.', :pid_dir => './tmp/pids', :log_dir => './log', :queues => ['test_queue']}],
+        ['delayed_job.2', {:quiet => true, :pid_delimiter => '.', :pid_dir => './tmp/pids', :log_dir => './log', :queues => ['test_queue']}],
+        ['delayed_job.3', {:quiet => true, :pid_delimiter => '.', :pid_dir => './tmp/pids', :log_dir => './log', :queues => ['test_queue']}],
+        ['delayed_job.4', {:quiet => true, :pid_delimiter => '.', :pid_dir => './tmp/pids', :log_dir => './log', :queues => ['test_queue']}],
+        ['delayed_job.5', {:quiet => true, :pid_delimiter => '.', :pid_dir => './tmp/pids', :log_dir => './log', :queues => %w[mailers misc]}],
+        ['delayed_job.6', {:quiet => true, :pid_delimiter => '.', :pid_dir => './tmp/pids', :log_dir => './log', :queues => %w[mailers misc]}]
       ].each do |args|
         expect(command).to receive(:run_process).with(*args).once
       end


### PR DESCRIPTION
## Description
I suggest adding an additional a `pid_delimiter` attribute for the daemons gem. This attribute does not affect on compatibility with previous versions `delayed_job` or `demons` gems.

I also can add additional tests regading this changes if the changes will make sense.

Fixes #1080