### PR TITLE
Add option to exclude locked jobs (i.e. currently being processed) in…

### DIFF
--- a/lib/delayed/tasks.rb
+++ b/lib/delayed/tasks.rb
@@ -27,7 +27,7 @@ namespace :jobs do
   end
 
   desc "Exit with error status if any jobs older than max_age seconds haven't been attempted yet."
-  task :check, [:max_age,:not_locked] => :environment do |_, args|
+  task :check, [:max_age, :not_locked] => :environment do |_, args|
     args.with_defaults(:max_age => 300, :not_locked => false)
 
     unprocessed_jobs = Delayed::Job.where('attempts = 0 AND created_at < ?', Time.now - args[:max_age].to_i)

--- a/lib/delayed/tasks.rb
+++ b/lib/delayed/tasks.rb
@@ -27,10 +27,12 @@ namespace :jobs do
   end
 
   desc "Exit with error status if any jobs older than max_age seconds haven't been attempted yet."
-  task :check, [:max_age] => :environment do |_, args|
-    args.with_defaults(:max_age => 300)
+  task :check, [:max_age,:not_locked] => :environment do |_, args|
+    args.with_defaults(:max_age => 300, :not_locked => false)
 
-    unprocessed_jobs = Delayed::Job.where('attempts = 0 AND created_at < ?', Time.now - args[:max_age].to_i).count
+    unprocessed_jobs = Delayed::Job.where('attempts = 0 AND created_at < ?', Time.now - args[:max_age].to_i)
+    unprocessed_jobs = unprocessed_jobs.where('AND locked_at IS NULL') if args[:not_locked]
+    unprocessed_jobs = unprocessed_jobs.count
 
     if unprocessed_jobs > 0
       raise "#{unprocessed_jobs} jobs older than #{args[:max_age]} seconds have not been processed yet"


### PR DESCRIPTION
… jobs:check.

If a job is currently being processed, we want an option to exclude them from being reported in `jobs:check`.

`jobs:check`'s primary purpose should be to see the outstanding queue, not determining long-running jobs. 

Made this option default to false so no breaking changes but simply pass `true` for `not_locked` to exclude them from this check.