### PR TITLE
Fix for change in Psych loading

### DIFF
--- a/lib/delayed/psych_ext.rb
+++ b/lib/delayed/psych_ext.rb
@@ -28,7 +28,13 @@ module Delayed
       end
 
       def visit_Psych_Nodes_Mapping(object) # rubocop:disable CyclomaticComplexity, MethodName, PerceivedComplexity
-        return revive(Psych.load_tags[object.tag], object) if Psych.load_tags[object.tag]
+        klass = Psych.load_tags[object.tag]
+        if klass
+          # Implementation changed here https://github.com/ruby/psych/commit/2c644e184192975b261a81f486a04defa3172b3f
+          # load_tags used to have class values, now the values are strings
+          klass = resolve_class(klass) if klass.is_a?(String)
+          return revive(klass, object)
+        end
 
         case object.tag
         when %r{^!ruby/object}

--- a/spec/psych_ext_spec.rb
+++ b/spec/psych_ext_spec.rb
@@ -3,10 +3,32 @@ require 'helper'
 describe 'Psych::Visitors::ToRuby', :if => defined?(Psych::Visitors::ToRuby) do
   context BigDecimal do
     it 'deserializes correctly' do
-      deserialized = YAML.load("--- !ruby/object:BigDecimal 18:0.1337E2\n...\n")
+      deserialized = YAML.load_dj("--- !ruby/object:BigDecimal 18:0.1337E2\n...\n")
 
       expect(deserialized).to be_an_instance_of(BigDecimal)
       expect(deserialized).to eq(BigDecimal('13.37'))
+    end
+  end
+
+  context 'load_tag handling' do
+    # This only broadly works in ruby 2.0 but will cleanly work through load_dj
+    # here because this class is so simple it only touches our extention
+    YAML.load_tags['!ruby/object:RenamedClass'] = SimpleJob
+    # This is how ruby 2.1 and newer works throughout the yaml handling
+    YAML.load_tags['!ruby/object:RenamedString'] = 'SimpleJob'
+
+    it 'deserializes class tag' do
+      deserialized = YAML.load_dj("--- !ruby/object:RenamedClass\ncheck: 12\n")
+
+      expect(deserialized).to be_an_instance_of(SimpleJob)
+      expect(deserialized.instance_variable_get(:@check)).to eq(12)
+    end
+
+    it 'deserializes string tag' do
+      deserialized = YAML.load_dj("--- !ruby/object:RenamedString\ncheck: 12\n")
+
+      expect(deserialized).to be_an_instance_of(SimpleJob)
+      expect(deserialized.instance_variable_get(:@check)).to eq(12)
     end
   end
 end


### PR DESCRIPTION
It is very rare to hit this, but Rails uses it to handle class renames so data can deserialize after upgrading rails.

https://github.com/rails/rails/commit/c3675f50d2e59b7fc173d7b332860c4b1a24a726#diff-0543aa8566327ece879b8ce6f394d391R185

This update allows us to handle either version of the load_tags data.