### PR TITLE
Display warning if both pool and identifier flags are specified

### DIFF
--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -72,6 +72,7 @@ module Delayed
           @options[:queues] = queue.split(',')
         end
         opt.on('--pool=queue1[,queue2][:worker_count]', 'Specify queues and number of workers for a worker pool') do |pool|
+          warn '--identifier is ignored because --pool is specified and used.' if @options[:identifier]
           parse_worker_pool(pool)
         end
         opt.on('--exit-on-complete', 'Exit when no more jobs are available to run. This will exit if all jobs are scheduled to run in the future.') do

--- a/spec/delayed/command_spec.rb
+++ b/spec/delayed/command_spec.rb
@@ -176,4 +176,16 @@ describe Delayed::Command do
       command.daemonize
     end
   end
+
+  describe 'when both --pool and --identifier are specified' do
+    it 'should ignore --identifier and display warning' do
+      command = nil
+      expect { command = Delayed::Command.new(['--identifier=42', '--pool=mailers']) }
+        .to output(/--identifier is ignored/).to_stderr
+
+      expect(command.worker_pools).to eq [
+        [['mailers'], 1],
+      ]
+    end
+  end
 end


### PR DESCRIPTION
This PR changes `delayed_job` command line to show warning like `--identifier is ignored because --pool is specified and used.` when both `--pool` and `--identifier` flags are specified. It should fix #1070.