### PR TITLE
Fix for daemon options with arguments

### DIFF
--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -78,7 +78,7 @@ module Delayed
           @options[:exit_on_complete] = true
         end
         opt.on('--daemon-options a, b, c', Array, 'options to be passed through to daemons gem') do |daemon_options|
-          @daemon_options = daemon_options
+          @daemon_options = daemon_options.map { |o| o.split(' ') }.flatten
         end
       end
       @args = opts.parse!(args) + (@daemon_options || [])


### PR DESCRIPTION
Some Daemon options take their own arguments. These weren't gettng
passed in to the deamons gem properly. With this, is we...

delayed_job stop --daemon-options '-w 42'

...the -w 42 gets passed through as expected.

I'm wide open to a cleaner/less hacky way to do this, but under a time crunch here to make this work quick, so this is what I've got at the moment.

I didn't see where `--daemon-options` was currently being tested within `delayed_jobs` so didn't update the tests.   