### PR TITLE
Improve payload_object logging

### DIFF
--- a/lib/delayed/performable_method.rb
+++ b/lib/delayed/performable_method.rb
@@ -15,7 +15,7 @@ module Delayed
     end
 
     def display_name
-      if object.is_a?(Class)
+      if object.is_a?(Class) || object.is_a?(Module)
         "#{object}.#{method_name}"
       else
         "#{object.class}##{method_name}"


### PR DESCRIPTION
Just a small logging improvement for Module methods. 

At the moment logging is not very usefull: `Module#call`