### PR TITLE
Make .delay method work with ActionMailer::Parameterized::Mailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,10 @@ end
 
 If you ever want to call a `handle_asynchronously`'d method without Delayed Job, for instance while debugging something at the console, just add `_without_delay` to the method name. For instance, if your original method was `foo`, then call `foo_without_delay`.
 
-Rails 3 Mailers
-===============
-Due to how mailers are implemented in Rails 3, we had to do a little work around to get delayed_job to work.
+Rails Mailers
+=============
+Delayed Job uses special syntax for Rails Mailers.
+Do not call the `.deliver` method when using `.delay`.
 
 ```ruby
 # without delayed_job
@@ -179,12 +180,16 @@ Notifier.signup(@user).deliver
 # with delayed_job
 Notifier.delay.signup(@user)
 
-# with delayed_job running at a specific time
+# delayed_job running at a specific time
 Notifier.delay(run_at: 5.minutes.from_now).signup(@user)
+
+# when using parameters, the .with method must be called before the .delay method 
+Notifier.with(foo: 1, bar: 2).delay.signup(@user)
 ```
 
-Remove the `.deliver` method to make it work. It's not ideal, but it's the best
-we could do for now.
+You may also wish to consider using
+[Active Job with Action Mailer](https://edgeguides.rubyonrails.org/active_job_basics.html#action-mailer)
+which provides convenient `.deliver_later` syntax that forwards to Delayed Job under-the-hood.
 
 Named Queues
 ============

--- a/lib/delayed_job.rb
+++ b/lib/delayed_job.rb
@@ -16,7 +16,7 @@ require 'delayed/railtie' if defined?(Rails::Railtie)
 ActiveSupport.on_load(:action_mailer) do
   require 'delayed/performable_mailer'
   ActionMailer::Base.extend(Delayed::DelayMail)
-  ActionMailer::Parameterized::Mailer.include(Delayed::DelayMail)
+  ActionMailer::Parameterized::Mailer.include(Delayed::DelayMail) if defined?(ActionMailer::Parameterized::Mailer)
 end
 
 module Delayed

--- a/lib/delayed_job.rb
+++ b/lib/delayed_job.rb
@@ -16,6 +16,7 @@ require 'delayed/railtie' if defined?(Rails::Railtie)
 ActiveSupport.on_load(:action_mailer) do
   require 'delayed/performable_mailer'
   ActionMailer::Base.extend(Delayed::DelayMail)
+  ActionMailer::Parameterized::Mailer.include(Delayed::DelayMail)
 end
 
 module Delayed

--- a/spec/performable_mailer_spec.rb
+++ b/spec/performable_mailer_spec.rb
@@ -46,11 +46,11 @@ if defined?(ActionMailer::Parameterized::Mailer)
     describe 'delay' do
       it 'enqueues a PerformableEmail job' do
         expect do
-          job = MyMailer.with(foo: 1, bar: 2).delay.signup('john@example.com')
+          job = MyMailer.with(:foo => 1, :bar => 2).delay.signup('john@example.com')
           expect(job.payload_object.class).to eq(Delayed::PerformableMailer)
           expect(job.payload_object.object.class).to eq(ActionMailer::Parameterized::Mailer)
           expect(job.payload_object.object.instance_variable_get('@mailer')).to eq(MyMailer)
-          expect(job.payload_object.object.instance_variable_get('@params')).to eq(foo: 1, bar: 2)
+          expect(job.payload_object.object.instance_variable_get('@params')).to eq(:foo => 1, :bar => 2)
           expect(job.payload_object.method_name).to eq(:signup)
           expect(job.payload_object.args).to eq(['john@example.com'])
         end.to change { Delayed::Job.count }.by(1)
@@ -60,7 +60,7 @@ if defined?(ActionMailer::Parameterized::Mailer)
     describe 'delay on a mail object' do
       it 'raises an exception' do
         expect do
-          MyMailer.with(foo: 1, bar: 2).signup('john@example.com').delay
+          MyMailer.with(:foo => 1, :bar => 2).signup('john@example.com').delay
         end.to raise_error(RuntimeError)
       end
     end

--- a/spec/performable_mailer_spec.rb
+++ b/spec/performable_mailer_spec.rb
@@ -40,3 +40,29 @@ describe ActionMailer::Base do
     end
   end
 end
+
+if defined?(ActionMailer::Parameterized::Mailer)
+  describe ActionMailer::Parameterized::Mailer do
+    describe 'delay' do
+      it 'enqueues a PerformableEmail job' do
+        expect do
+          job = MyMailer.with(foo: 1, bar: 2).delay.signup('john@example.com')
+          expect(job.payload_object.class).to eq(Delayed::PerformableMailer)
+          expect(job.payload_object.object.class).to eq(ActionMailer::Parameterized::Mailer)
+          expect(job.payload_object.object.instance_variable_get('@mailer')).to eq(MyMailer)
+          expect(job.payload_object.object.instance_variable_get('@params')).to eq(foo: 1, bar: 2)
+          expect(job.payload_object.method_name).to eq(:signup)
+          expect(job.payload_object.args).to eq(['john@example.com'])
+        end.to change { Delayed::Job.count }.by(1)
+      end
+    end
+
+    describe 'delay on a mail object' do
+      it 'raises an exception' do
+        expect do
+          MyMailer.with(foo: 1, bar: 2).signup('john@example.com').delay
+        end.to raise_error(RuntimeError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Rails 5.1 introduced [parameterized mailers](https://github.com/rails/rails/pull/27825)

This PR unifies the DelayedJob behavior of ActionMailer::Base and ActionMailer::Parameterized::Mailer

Now, the following syntax works equivalently:

```ruby
# works currently
MyMailer.delay.my_method

# this PR makes the following work
MyMailer.with(foo: 1, bar: 2).delay.my_method
```

Note that ActionMailer::Parameterized::Mailer does not inherit ActionMailer::Base (moreover, the `.with()` method returns an object instance, hence we use `include` rather than `extend`)