### PR TITLE
Unlock mime-type gem version to support Ruby 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ platforms :jruby do
     gem 'activerecord-jdbcsqlite3-adapter'
   end
   gem 'jruby-openssl'
-  gem 'mime-types', ['~> 2.6', '< 2.99']
+  gem 'mime-types', '>= 2.6'
   if ENV['RAILS_VERSION'] == 'edge'
     gem 'railties', :github => 'rails/rails'
   else


### PR DESCRIPTION
This pull request addresses these syntax errors which has been fixed by https://github.com/mime-types/ruby-mime-types/pull/146

```ruby
$ ruby -v
ruby 3.0.0dev (2020-10-24T13:53:53Z master 148961adcd) [x86_64-linux]
$ bundle exec rake spec

An error occurred while loading ./spec/delayed/command_spec.rb.
Failure/Error: require 'coveralls'

SyntaxError:
  /home/yahonda/.rbenv/versions/3.0.0-dev/lib/ruby/gems/3.0.0/gems/mime-types-2.6.2/lib/mime/types/logger.rb:26: _1 is reserved for numbered parameter
  /home/yahonda/.rbenv/versions/3.0.0-dev/lib/ruby/gems/3.0.0/gems/mime-types-2.6.2/lib/mime/types/logger.rb:26: _2 is reserved for numbered parameter
  /home/yahonda/.rbenv/versions/3.0.0-dev/lib/ruby/gems/3.0.0/gems/mime-types-2.6.2/lib/mime/types/logger.rb:26: _3 is reserved for numbered parameter
/home/yahonda/.rbenv/versions/3.0.0-dev/lib/ruby/gems/3.0.0/gems/mime-types-2.6.2/lib/mime/types/columnar.rb:16: warning: already initialized constant MIME::Types::Columnar::LOAD_MUTEX
/home/yahonda/.rbenv/versions/3.0.0-dev/lib/ruby/gems/3.0.0/gems/mime-types-2.6.2/lib/mime/types/columnar.rb:16: warning: previous definition of LOAD_MUTEX was here
```