### PR TITLE
rails 6.1 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     - RAILS_VERSION="~> 5.1.0"
     - RAILS_VERSION="~> 5.2.0"
     - RAILS_VERSION="~> 6.0.0"
+    - RAILS_VERSION="~> 6.1.0.rc1"
     - RAILS_VERSION="edge"
 rvm:
   - 2.3.8
@@ -29,6 +30,8 @@ matrix:
       env: RAILS_VERSION="~> 5.1.0"
     - rvm: jruby-9.2.7.0
       env: RAILS_VERSION="~> 5.2.0"
+    - rvm: jruby-9.2.7.0
+      env: RAILS_VERSION="~> 6.1.0.rc1"
   fast_finish: true
   # legacy testing
   # things still run and we don't have a good reason to break it
@@ -55,6 +58,10 @@ matrix:
       env: RAILS_VERSION="~> 6.0.0"
     - rvm: 2.4.5
       env: RAILS_VERSION="~> 6.0.0"
+    - rvm: 2.3.8
+      env: RAILS_VERSION="~> 6.1.0.rc1"
+    - rvm: 2.4.5
+      env: RAILS_VERSION="~> 6.1.0.rc1"
     - rvm: 2.3.8
       env: RAILS_VERSION="edge"
     - rvm: 2.4.5

--- a/delayed_job.gemspec
+++ b/delayed_job.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'activesupport', ['>= 3.0', '< 6.1']
+  spec.add_dependency 'activesupport', ['>= 3.0', '<= 6.1']
   spec.authors        = ['Brandon Keepers', 'Brian Ryckbost', 'Chris Gaffney', 'David Genord II', 'Erik Michaels-Ober', 'Matt Griffin', 'Steve Richert', 'Tobias Lütke']
   spec.description    = 'Delayed_job (or DJ) encapsulates the common pattern of asynchronously executing longer tasks in the background. It is a direct extraction from Shopify where the job table is responsible for a multitude of core tasks.'
   spec.email          = ['brian@collectiveidea.com']


### PR DESCRIPTION
in order to upgrade to rails 6.1 we have to fix activesupport dependency