### PR TITLE
Allow unreleased versions of Rails 7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         rails_version:
           - '5.2.0'
           - '6.0.0'
-          - '6.1.0.rc2'
+          - '6.1.3'
           - 'edge'
         include:
           #

--- a/delayed_job.gemspec
+++ b/delayed_job.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'activesupport', ['>= 3.0', '< 6.2']
+  spec.add_dependency 'activesupport', ['>= 3.0', '< 7.0']
   spec.authors        = ['Brandon Keepers', 'Brian Ryckbost', 'Chris Gaffney', 'David Genord II', 'Erik Michaels-Ober', 'Matt Griffin', 'Steve Richert', 'Tobias Lütke']
   spec.description    = 'Delayed_job (or DJ) encapsulates the common pattern of asynchronously executing longer tasks in the background. It is a direct extraction from Shopify where the job table is responsible for a multitude of core tasks.'
   spec.email          = ['brian@collectiveidea.com']


### PR DESCRIPTION
Rails 6.2 is being skipped in favor of Rails 7. So we shouldn't reference 6.2 in the gemspec.

I copied the implementation from https://github.com/cgriego/active_attr/pull/183 / https://github.com/cgriego/active_attr/commit/25ef02d9fc3702d59696002b0d04a7d1def283c1