### PR TITLE
Don't log time, logger can be formatted to include time

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -282,7 +282,7 @@ module Delayed
       unless level.is_a?(String)
         level = Logger::Severity.constants.detect { |i| Logger::Severity.const_get(i) == level }.to_s.downcase
       end
-      logger.send(level, "#{Time.now.strftime('%FT%T%z')}: #{text}")
+      logger.send(level, text)
     end
 
     def max_attempts(job)


### PR DESCRIPTION
## Summary

Including time in logger pollutes loggers that already have a timestamp included. Developers can set their own logger through `Delayed::Worker.logger`. Additionally, common logging platforms are able to determine time on ingestion such as Cloudwatch, Datadog, Scalyr, etc.

## Background

This pr initially included time 10 years ago when Rails didn't support time in logs: https://github.com/collectiveidea/delayed_job/issues/37. 5 years later, this issue was opened asking for the same fix https://github.com/collectiveidea/delayed_job/pull/859 but Rails still did not support it. Now, this is possible with Rails loggers using your own logger and setting `Rails.logger.datetime_format` to your own desired format, see https://stackify.com/rails-logger-and-rails-logging-best-practices/ for examples/tutorial.

