### PR TITLE
Rails 7.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         ruby: [2.7, 3.0, 3.1, ruby-head]
         rails_version:
-          - '7.0.0'
+          - '7.0.1'
           - 'edge'
         include:
           - ruby: 2.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, 3.0, ruby-head]
+        ruby: [2.7, 3.0, 3.1, ruby-head]
         rails_version:
           - '7.0.0'
           - 'edge'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,18 +12,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, 3.0, 3.1, ruby-head]
+        ruby: ['2.7', '3.0', '3.1', 'ruby-head']
         rails_version:
           - '7.0.1'
           - 'edge'
         include:
-          - ruby: 2.5
+          - ruby: '2.5'
             rails_version: '6.1.0'
-          - ruby: 2.6
+          - ruby: '2.6'
             rails_version: '6.1.0'
-          - ruby: 2.7
+          - ruby: '2.7'
             rails_version: '6.1.0'
-          - ruby: 3.0
+          - ruby: '3.0'
             rails_version: '6.1.0'
           - ruby: jruby-9.2
             rails_version: '6.1.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         ruby: [2.7, 3.0, ruby-head]
         rails_version:
-          - '7.0.0.alpha2'
+          - '7.0.0.rc1'
           - 'edge'
         include:
           - ruby: 2.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         ruby: [2.7, 3.0, ruby-head]
         rails_version:
-          - '7.0.0.rc1'
+          - '7.0.0'
           - 'edge'
         include:
           - ruby: 2.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, jruby, jruby-head, ruby-head]
+        ruby: [2.7, 3.0, ruby-head]
         rails_version:
-          - '5.2.0'
-          - '6.0.0'
-          - '6.1.0.rc2'
+          - '7.0.0.alpha2'
           - 'edge'
         include:
+          - ruby: 2.5
+            rails_version: '6.1.0'
+          - ruby: 2.6
+            rails_version: '6.1.0'
+          - ruby: 2.7
+            rails_version: '6.1.0'
+          - ruby: 3.0
+            rails_version: '6.1.0'
+          - ruby: jruby
+            rails_version: '6.1.0'
+          - ruby: jruby-head
+            rails_version: '6.1.0'
           #
           # The past
           #
@@ -33,6 +43,18 @@ jobs:
             rails_version: '5.0.0'
           - ruby: 2.5
             rails_version: '5.1.0'
+          - ruby: 2.5
+            rails_version: '5.2.0'
+          - ruby: 2.5
+            rails_version: '6.0.0'
+          - ruby: 2.6
+            rails_version: '6.0.0'
+          - ruby: 2.7
+            rails_version: '6.0.0'
+          - ruby: jruby
+            rails_version: '6.0.0'
+          - ruby: jruby-head
+            rails_version: '6.0.0'
 
     continue-on-error: ${{ matrix.rails_version == 'edge' || endsWith(matrix.ruby, 'head') }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
             rails_version: '6.1.0'
           - ruby: 3.0
             rails_version: '6.1.0'
-          - ruby: jruby
+          - ruby: jruby-9.2
+            rails_version: '6.1.0'
+          - ruby: jruby-9.3
             rails_version: '6.1.0'
           - ruby: jruby-head
             rails_version: '6.1.0'
@@ -51,7 +53,9 @@ jobs:
             rails_version: '6.0.0'
           - ruby: 2.7
             rails_version: '6.0.0'
-          - ruby: jruby
+          - ruby: jruby-9.2
+            rails_version: '6.0.0'
+          - ruby: jruby-9.3
             rails_version: '6.0.0'
           - ruby: jruby-head
             rails_version: '6.0.0'

--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,16 @@ end
 platforms :jruby do
   if ENV['RAILS_VERSION'] == '4.2.0'
     gem 'activerecord-jdbcsqlite3-adapter', '< 50.0'
-  elsif ENV['RAILS_VERSION'] == 'edge' || ENV['RAILS_VERSION'] == '6.1.0.rc2'
-    gem 'activerecord-jdbcsqlite3-adapter', :github => 'jruby/activerecord-jdbc-adapter'
+  elsif ENV['RAILS_VERSION'] == '5.0.0'
+    gem 'activerecord-jdbcsqlite3-adapter', '~> 50.0'
+  elsif ENV['RAILS_VERSION'] == '5.1.0'
+    gem 'activerecord-jdbcsqlite3-adapter', '~> 51.0'
+  elsif ENV['RAILS_VERSION'] == '5.2.0'
+    gem 'activerecord-jdbcsqlite3-adapter', '~> 52.0'
+  elsif ENV['RAILS_VERSION'] == '6.0.0'
+    gem 'activerecord-jdbcsqlite3-adapter', '~> 60.0'
+  elsif ENV['RAILS_VERSION'] == '6.1.0'
+    gem 'activerecord-jdbcsqlite3-adapter', '~> 61.0'
   else
     gem 'activerecord-jdbcsqlite3-adapter'
   end
@@ -27,7 +35,7 @@ platforms :jruby do
   elsif ENV['RAILS_VERSION']
     gem 'railties', "~> #{ENV['RAILS_VERSION']}"
   else
-    gem 'railties', ['>= 3.0', '< 6.2']
+    gem 'railties', ['>= 3.0', '< 7.0']
   end
 end
 
@@ -43,8 +51,8 @@ group :test do
     gem 'actionmailer', "~> #{ENV['RAILS_VERSION']}"
     gem 'activerecord', "~> #{ENV['RAILS_VERSION']}"
   else
-    gem 'actionmailer', ['>= 3.0', '< 6.2']
-    gem 'activerecord', ['>= 3.0', '< 6.2']
+    gem 'actionmailer', ['>= 3.0', '< 7.1']
+    gem 'activerecord', ['>= 3.0', '< 7.1']
   end
 
   gem 'rspec', '>= 3'

--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,6 @@ platforms :ruby do
   else
     gem 'sqlite3'
   end
-
-  gem 'net/smtp' if ENV['RAILS_VERSION'] == 'ruby-head'
 end
 
 platforms :jruby do

--- a/Gemfile
+++ b/Gemfile
@@ -30,13 +30,6 @@ platforms :jruby do
   end
   gem 'jruby-openssl'
   gem 'mime-types', ['~> 2.6', '< 2.99']
-  if ENV['RAILS_VERSION'] == 'edge'
-    gem 'railties', :github => 'rails/rails'
-  elsif ENV['RAILS_VERSION']
-    gem 'railties', "~> #{ENV['RAILS_VERSION']}"
-  else
-    gem 'railties', ['>= 3.0', '< 7.1']
-  end
 end
 
 platforms :rbx do

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ platforms :jruby do
   elsif ENV['RAILS_VERSION']
     gem 'railties', "~> #{ENV['RAILS_VERSION']}"
   else
-    gem 'railties', ['>= 3.0', '< 7.0']
+    gem 'railties', ['>= 3.0', '< 7.1']
   end
 end
 
@@ -49,12 +49,15 @@ group :test do
   if ENV['RAILS_VERSION'] == 'edge'
     gem 'actionmailer', :github => 'rails/rails'
     gem 'activerecord', :github => 'rails/rails'
+    gem 'railties', :github => 'rails/rails'
   elsif ENV['RAILS_VERSION']
     gem 'actionmailer', "~> #{ENV['RAILS_VERSION']}"
     gem 'activerecord', "~> #{ENV['RAILS_VERSION']}"
+    gem 'railties', "~> #{ENV['RAILS_VERSION']}"
   else
     gem 'actionmailer', ['>= 3.0', '< 7.1']
     gem 'activerecord', ['>= 3.0', '< 7.1']
+    gem 'railties', ['>= 3.0', '< 7.1']
   end
 
   gem 'rspec', '>= 3'

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ platforms :ruby do
   else
     gem 'sqlite3'
   end
+
+  gem 'net/smtp' if ENV['RAILS_VERSION'] == 'ruby-head'
 end
 
 platforms :jruby do

--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,10 @@ group :test do
     gem 'activerecord', ['>= 3.0', '< 7.1']
     gem 'railties', ['>= 3.0', '< 7.1']
   end
-  gem 'net-smtp' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0-dev')
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0-dev')
+    gem 'digest', '>= 3.1.0.pre2'
+    gem 'net-smtp'
+  end
   gem 'rspec', '>= 3'
   gem 'simplecov', :require => false
   if /\A2.[12]/ =~ RUBY_VERSION

--- a/Gemfile
+++ b/Gemfile
@@ -59,10 +59,7 @@ group :test do
     gem 'activerecord', ['>= 3.0', '< 7.1']
     gem 'railties', ['>= 3.0', '< 7.1']
   end
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0-dev')
-    gem 'digest', '>= 3.1.0.pre2'
-    gem 'net-smtp'
-  end
+  gem 'net-smtp' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
   gem 'rspec', '>= 3'
   gem 'simplecov', :require => false
   if /\A2.[12]/ =~ RUBY_VERSION

--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ group :test do
     gem 'activerecord', ['>= 3.0', '< 7.1']
     gem 'railties', ['>= 3.0', '< 7.1']
   end
-
+  gem 'net-smtp' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0-dev')
   gem 'rspec', '>= 3'
   gem 'simplecov', :require => false
   if /\A2.[12]/ =~ RUBY_VERSION

--- a/delayed_job.gemspec
+++ b/delayed_job.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'activesupport', ['>= 3.0', '< 6.2']
+  spec.add_dependency 'activesupport', ['>= 3.0', '< 7.1']
   spec.authors        = ['Brandon Keepers', 'Brian Ryckbost', 'Chris Gaffney', 'David Genord II', 'Erik Michaels-Ober', 'Matt Griffin', 'Steve Richert', 'Tobias Lütke']
   spec.description    = 'Delayed_job (or DJ) encapsulates the common pattern of asynchronously executing longer tasks in the background. It is a direct extraction from Shopify where the job table is responsible for a multitude of core tasks.'
   spec.email          = ['brian@collectiveidea.com']

--- a/lib/delayed/syck_ext.rb
+++ b/lib/delayed/syck_ext.rb
@@ -37,10 +37,6 @@ module YAML
   def load_dj(yaml)
     # See https://github.com/dtao/safe_yaml
     # When the module is there, we need to load our YAML like this...
-    if Object.const_defined?(:SafeYAML)
-      load(yaml, :safe => false)
-    elsif respond_to?(:unsafe_load) # psych >= 3.3.2
-      unsafe_load(yaml)
-    end
+    respond_to?(:unsafe_load) ? load(yaml, :safe => false) : load(yaml)
   end
 end

--- a/lib/delayed/syck_ext.rb
+++ b/lib/delayed/syck_ext.rb
@@ -36,7 +36,11 @@ end
 module YAML
   def load_dj(yaml)
     # See https://github.com/dtao/safe_yaml
-    # When the method is there, we need to load our YAML like this...
-    respond_to?(:unsafe_load) ? load(yaml, :safe => false) : load(yaml)
+    # When the module is there, we need to load our YAML like this...
+    if Object.const_defined?(:SafeYAML)
+      load(yaml, :safe => false)
+    elsif respond_to?(:unsafe_load) # psych >= 3.3.2
+      unsafe_load(yaml)
+    end
   end
 end

--- a/spec/delayed/command_spec.rb
+++ b/spec/delayed/command_spec.rb
@@ -159,16 +159,18 @@ describe Delayed::Command do
   describe 'running worker pools defined by multiple --pool arguments' do
     it 'should run the correct worker processes' do
       command = Delayed::Command.new(['--pool=*:1', '--pool=test_queue:4', '--pool=mailers,misc:2'])
-      expect(FileUtils).to receive(:mkdir_p).with('./tmp/pids').once
+      pid_dir = File.expand_path('./tmp/pids')
+      log_dir = File.expand_path('./log')
+      expect(FileUtils).to receive(:mkdir_p).with(pid_dir).once
 
       [
-        ['delayed_job.0', {:quiet => true, :pid_dir => './tmp/pids', :log_dir => './log', :queues => []}],
-        ['delayed_job.1', {:quiet => true, :pid_dir => './tmp/pids', :log_dir => './log', :queues => ['test_queue']}],
-        ['delayed_job.2', {:quiet => true, :pid_dir => './tmp/pids', :log_dir => './log', :queues => ['test_queue']}],
-        ['delayed_job.3', {:quiet => true, :pid_dir => './tmp/pids', :log_dir => './log', :queues => ['test_queue']}],
-        ['delayed_job.4', {:quiet => true, :pid_dir => './tmp/pids', :log_dir => './log', :queues => ['test_queue']}],
-        ['delayed_job.5', {:quiet => true, :pid_dir => './tmp/pids', :log_dir => './log', :queues => %w[mailers misc]}],
-        ['delayed_job.6', {:quiet => true, :pid_dir => './tmp/pids', :log_dir => './log', :queues => %w[mailers misc]}]
+        ['delayed_job.0', {:quiet => true, :pid_dir => pid_dir, :log_dir => log_dir, :queues => []}],
+        ['delayed_job.1', {:quiet => true, :pid_dir => pid_dir, :log_dir => log_dir, :queues => ['test_queue']}],
+        ['delayed_job.2', {:quiet => true, :pid_dir => pid_dir, :log_dir => log_dir, :queues => ['test_queue']}],
+        ['delayed_job.3', {:quiet => true, :pid_dir => pid_dir, :log_dir => log_dir, :queues => ['test_queue']}],
+        ['delayed_job.4', {:quiet => true, :pid_dir => pid_dir, :log_dir => log_dir, :queues => ['test_queue']}],
+        ['delayed_job.5', {:quiet => true, :pid_dir => pid_dir, :log_dir => log_dir, :queues => %w[mailers misc]}],
+        ['delayed_job.6', {:quiet => true, :pid_dir => pid_dir, :log_dir => log_dir, :queues => %w[mailers misc]}]
       ].each do |args|
         expect(command).to receive(:run_process).with(*args).once
       end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -21,6 +21,7 @@ require 'rspec'
 
 require 'action_mailer'
 require 'active_record'
+require 'rails'
 
 require 'delayed_job'
 require 'delayed/backend/shared_spec'
@@ -36,14 +37,7 @@ else
 end
 ENV['RAILS_ENV'] = 'test'
 
-# Trigger AR to initialize
-ActiveRecord::Base # rubocop:disable Void
-
-module Rails
-  def self.root
-    '.'
-  end
-end
+FakeApp = Class.new(Rails::Application)
 
 Delayed::Worker.backend = :test
 
@@ -75,6 +69,8 @@ class Story < ActiveRecord::Base
 
   handle_asynchronously :whatever
 end
+
+FakeApp.initialize!
 
 RSpec.configure do |config|
   config.after(:each) do

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -38,6 +38,7 @@ end
 ENV['RAILS_ENV'] = 'test'
 
 FakeApp = Class.new(Rails::Application)
+FakeApp.config.eager_load = false
 
 Delayed::Worker.backend = :test
 

--- a/spec/yaml_ext_spec.rb
+++ b/spec/yaml_ext_spec.rb
@@ -25,7 +25,7 @@ describe 'YAML' do
   it 'autoloads the class of an anonymous struct' do
     expect do
       yaml = "--- !ruby/struct\nn: 1\n"
-      object = YAML.load(yaml)
+      object = load_with_delayed_visitor(yaml)
       expect(object).to be_kind_of(Struct)
       expect(object.n).to eq(1)
     end.not_to raise_error


### PR DESCRIPTION
- Loose dependencies to allow Rails7 to be installed.
- Improved the CI setup to run tests with the latest Ruby and Rails.
    - jruby >= 9.3.0.0 fails, but I don't know how to fix it, so I leave it as it is.
    - fix tests that failed in non jruby environments.
