### PR TITLE
Exit after a fixed number of jobs executed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,10 @@ You can then do the following:
     # or to run in the foreground
     RAILS_ENV=production script/delayed_job run --exit-on-complete
 
+	# Exit after a specific number of jobs, irrespective of success or failure.
+	script/delayed_job start --exit-after=1
+	env EXIT_AFTER=4 rake jobs:work
+
 **Rails 4:** *replace script/delayed_job with bin/delayed_job*
 
 Workers can be running on any computer, as long as they have access to the

--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -80,6 +80,9 @@ module Delayed
         opt.on('--daemon-options a, b, c', Array, 'options to be passed through to daemons gem') do |daemon_options|
           @daemon_options = daemon_options
         end
+        opt.on('--exit-after N', 'Exit after executing N jobs.') do |n|
+          @options[:exit_after] = n.to_i
+        end
       end
       @args = opts.parse!(args) + (@daemon_options || [])
     end

--- a/lib/delayed/tasks.rb
+++ b/lib/delayed/tasks.rb
@@ -24,6 +24,7 @@ namespace :jobs do
 
     @worker_options[:sleep_delay] = ENV['SLEEP_DELAY'].to_i if ENV['SLEEP_DELAY']
     @worker_options[:read_ahead] = ENV['READ_AHEAD'].to_i if ENV['READ_AHEAD']
+    @worker_options[:exit_after] = ENV['EXIT_AFTER'].to_i if ENV['EXIT_AFTER']
   end
 
   desc "Exit with error status if any jobs older than max_age seconds haven't been attempted yet."


### PR DESCRIPTION
Add command line switch (--exit-after) or Environment
varaible (EXIT_AFTER),which causes work to exit after a specific
number of jobs, irrespective of success or failure.