### PR TITLE
Avoid rescuing WorkerTimeout when job times out

### DIFF
--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -549,7 +549,6 @@ shared_examples_for 'a delayed_job backend' do
         job = Delayed::Job.create :payload_object => LongRunningJob.new
         worker.run(job)
         expect(job.error).to_not be_nil
-        expect(job.reload.last_error).to match(/expired/)
         expect(job.reload.last_error).to match(/Delayed::Worker\.max_run_time is only 1 second/)
         expect(job.attempts).to eq(1)
       end

--- a/lib/delayed/exceptions.rb
+++ b/lib/delayed/exceptions.rb
@@ -2,10 +2,19 @@ require 'timeout'
 
 module Delayed
   class WorkerTimeout < Timeout::Error
+    attr_reader :job, :timeout_error
+
+    def initialize(job, timeout_error)
+      @job = job
+      @timeout_error = timeout_error
+    end
+
     def message
-      seconds = Delayed::Worker.max_run_time.to_i
+      seconds = (job.max_run_time || Delayed::Worker.max_run_time).to_i
       "#{super} (Delayed::Worker.max_run_time is only #{seconds} second#{seconds == 1 ? '' : 's'})"
     end
+
+    delegate :backtrace, :to => :timeout_error
   end
 
   class FatalBackendError < RuntimeError; end


### PR DESCRIPTION
When provided [an error class argument](https://github.com/ruby/timeout/blob/c4f1385c9adb316c5cbb649c6e85fadc65b6c8e6/lib/timeout.rb#L172), Ruby's Timeout library allows the [block to catch the provided exception](https://github.com/ruby/timeout/blob/c4f1385c9adb316c5cbb649c6e85fadc65b6c8e6/lib/timeout.rb#L161).

This means that when the Timeout library sends the [thread.raise](https://github.com/ruby/timeout/blob/c4f1385c9adb316c5cbb649c6e85fadc65b6c8e6/lib/timeout.rb#L86) signal to the running job, depending on the execution state of the thread (e.g. if when the signal is received, it's wrapped in a `rescue StandardError` statement), the job isn't actually halted.

At the same time, both the [mongoid](https://github.com/collectiveidea/delayed_job_mongoid/blob/f2baa9c48d906fb93e592c704c88979dbb663349/lib/delayed/backend/mongoid_mixin.rb#L81) and [activerecord](https://github.com/collectiveidea/delayed_job_active_record/blob/d65b0f9900f5b0c78c341c7c0209c2d138d64ec5/lib/delayed/backend/active_record.rb#L55) backends assume that jobs that are past their `max_run_time` threshold (even if they were locked by another worker) are valid candidates to be picked up. This ultimately leads to the same job to be potentially run in multiple workers at the same time.

This commit proposes a change in the way the library interacts with the `Timeout` module, by not providing a specific exception class. This triggers a different code flow within the library which prevents the job to be able to swallow the exception.

Here's a repo with a minimalistic example on how to replicate the problem: https://github.com/diogoosorio/delayed-job-timeout-example