### PR TITLE
CI: add Ruby 3.2 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0', '3.1', jruby-head, ruby-head]
+        ruby: ['2.7', '3.0', '3.1', '3.2', jruby-head, ruby-head]
         rails_version:
           - '6.0.0'
           - '6.1.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
           - ruby: jruby-9.2
             rails_version: '6.1.0'
 
-          # jruby-9.3
-          - ruby: jruby-9.3
+          # jruby-9.4
+          - ruby: jruby-9.4
             rails_version: '7.0.0'
-          - ruby: jruby-9.3
+          - ruby: jruby-9.4
             rails_version: 'edge'
 
           #


### PR DESCRIPTION
Ruby 3.2 has [been released](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/)! Let's add it to the CI build matrix and ensure the project is compatible.