### PR TITLE
Ensure `Array` has been decorated with `#extract_options`

### DIFF
--- a/lib/delayed/backend/job_preparer.rb
+++ b/lib/delayed/backend/job_preparer.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/extract_options'
+
 module Delayed
   module Backend
     class JobPreparer


### PR DESCRIPTION
(sorry for the missing description -- the github code editor doesn't make the PR generation flow entirely obvious) 

My team maintains a sinatra-based application that uses delayed_job (http://github.com/cloudfoundry/bosh). Only the `activesupport` gem is present as a dependency. We recently upgraded `activesupport` to latest in response to the [recent Rails CVE](https://github.com/advisories/GHSA-j6gc-792m-qgm2). After this change our integration tests began failing. 

What we have observed is in versions of activesupport > 6.0.x, the `#extract_options!` method is not "automatically" applied to Arrays. It is not clear to me when how this behavior change has been introduced, but I don't think it is too important, as I expect it is likely desired behavior from the Rails team (e.g, I see this behavior being explicitly loaded elsewhere in the Rails codebase) and probably best fixed by explicitly requiring this library. I notice there is a similar pattern in the delayed_job codebase (e.g. `lib/delayed/worker.rb`) for pulling in active_support dependencies. 

I suspect this is not an issue in your tests because it appears the entire Rails dependency stack is pulled in. I believe parts of Rails are likely to automatically load this file at some point which may explain why tests aren't failing and there are no other complaints from other users. 

For now we will likely workaround by explicitly loading this active_support file whenever we require delayed_job but it would be great if we could get this change integrated into delayed_job itself so we could remove this extra require call. 

Thank you! 