### PR TITLE
Improve PerformableMethod logging

### DIFF
--- a/lib/delayed/message_sending.rb
+++ b/lib/delayed/message_sending.rb
@@ -7,8 +7,8 @@ module Delayed
     end
 
     # rubocop:disable MethodMissing
-    def method_missing(method, *args)
-      Job.enqueue({:payload_object => @payload_class.new(@target, method.to_sym, args)}.merge(@options))
+    def method_missing(method, *args, &block)
+      Job.enqueue({:payload_object => @payload_class.new(@target, method.to_sym, args, &block)}.merge(@options))
     end
     # rubocop:enable MethodMissing
   end

--- a/lib/delayed/performable_method.rb
+++ b/lib/delayed/performable_method.rb
@@ -2,8 +2,9 @@ module Delayed
   class PerformableMethod
     attr_accessor :object, :method_name, :args
 
-    def initialize(object, method_name, args)
+    def initialize(object, method_name, args, &block)
       raise NoMethodError, "undefined method `#{method_name}' for #{object.inspect}" unless object.respond_to?(method_name, true)
+      warn "Ignored the block #{block.inspect} because it cannot be serialized." if block_given?
 
       if object.respond_to?(:persisted?) && !object.persisted?
         raise(ArgumentError, "job cannot be created for non-persisted record: #{object.inspect}")


### PR DESCRIPTION
Just a small logging improvement for `PerformableMethod`.
This PR adds warning message when `Object#delay` is called with a block given.

Use case:
The code below won't perform as intended because blocks cannot be serialized and thus a job will ignore the block.

```ruby
SomeModel.first.delay.tap do |record|
  record.touch # => raises "LocalJumpError: no block given"
end
```

I think it is convenient to display a warning like `Ignored the block XXX because it cannot be serialized.` when developers using the gem accidentally give block.


