### PR TITLE
Add pool name option to worker pools

### DIFF
--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -108,10 +108,11 @@ module Delayed
 
     def setup_pools
       worker_index = 0
-      @worker_pools.each do |queues, worker_count|
+      @worker_pools.each do |queues, worker_count, pool_name|
         options = @options.merge(:queues => queues)
+        process_name_base = pool_name ? "delayed_job.#{pool_name}" : "delayed_job"
         worker_count.times do
-          process_name = "delayed_job.#{worker_index}"
+          process_name = "#{process_name_base}.#{worker_index}"
           run_process(process_name, options)
           worker_index += 1
         end
@@ -147,10 +148,10 @@ module Delayed
     def parse_worker_pool(pool)
       @worker_pools ||= []
 
-      queues, worker_count = pool.split(':')
+      queues, worker_count, pool_name = pool.split(':')
       queues = ['*', '', nil].include?(queues) ? [] : queues.split(',')
       worker_count = (worker_count || 1).to_i rescue 1
-      @worker_pools << [queues, worker_count]
+      @worker_pools << [queues, worker_count, pool_name]
     end
 
     def root


### PR DESCRIPTION
I found myself debugging an error in production infrastructure that made some of the DJ workers to die (or not start at all) and I was having a hard time figuring out which of the pool where missing workers. 
This PR adds a 3rd optional parameter to the pool specification syntax to add a tag to the processes name that indicates the pool they belong to.

The syntax is `--pool=queue_1:30:a-pool-name` this will spawn 30 processes named `delayed_job.a-pool-name.{0..29}`. 

If omitted, then it uses the standard naming.