### PR TITLE
Allow identifier with multiple workers

### DIFF
--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -84,7 +84,7 @@ module Delayed
       @args = opts.parse!(args) + (@daemon_options || [])
     end
 
-    def daemonize # rubocop:disable PerceivedComplexity
+    def daemonize
       dir = @options[:pid_dir]
       FileUtils.mkdir_p(dir) unless File.exist?(dir)
 

--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -90,17 +90,11 @@ module Delayed
 
       if worker_pools
         setup_pools
-      elsif @options[:identifier]
-        # rubocop:disable GuardClause
-        if worker_count > 1
-          raise ArgumentError, 'Cannot specify both --number-of-workers and --identifier'
-        else
-          run_process("delayed_job.#{@options[:identifier]}", @options)
-        end
-        # rubocop:enable GuardClause
       else
         worker_count.times do |worker_index|
-          process_name = worker_count == 1 ? 'delayed_job' : "delayed_job.#{worker_index}"
+          process_name = 'delayed_job'
+          process_name += ".#{@options[:identifier]}" if @options[:identifier]
+          process_name += ".#{worker_index}" if worker_count > 1
           run_process(process_name, @options)
         end
       end


### PR DESCRIPTION
Hello,

Using identifiers with multiple workers has been prevented for 14 years at least. Maybe it is time to reconsider it.

This PR loosens up that restriction and allows multiple identified job workers to be started with the following process name format:

```
delayed_job(.<identifier>)(.<worker_index>)
```

Both fields are optional, so the default process name remains unchanged (`delayed_job`).