### PR TITLE
Use a block for expect to raise_exception

### DIFF
--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -106,7 +106,7 @@ describe Delayed::Worker do
       expect(Delayed::Job).to receive(:reserve).exactly(10).times.and_raise(Exception)
       worker = Delayed::Worker.new
       9.times { worker.work_off }
-      expect(lambda { worker.work_off }).to raise_exception Delayed::FatalBackendError
+      expect { worker.work_off }.to raise_exception Delayed::FatalBackendError
     end
 
     it 'allows the backend to attempt recovery from reservation errors' do


### PR DESCRIPTION
This was probably the only way to do it 10 years ago when it was added.