### PR TITLE
CI: update build matrix - Ruby 3.3 & Rails 7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         rails_version:
           - '6.1.0'
           - '7.0.0'
+          - '7.1.0'
           - 'edge'
         include:
           # Ruby 2.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2', jruby-head, ruby-head]
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', jruby-head, ruby-head]
         rails_version:
           - '6.0.0'
           - '6.1.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    name: Test (Ruby ${{ matrix.ruby }}, Rails ${{ matrix.rails_version }})
+    runs-on: ubuntu-${{ matrix.ubuntu }}
     strategy:
       fail-fast: false
       matrix:
@@ -18,32 +19,41 @@ jobs:
           - '7.0.0'
           - '7.1.0'
           - 'edge'
+        ubuntu: [latest]
         include:
           # Ruby 2.6
           - ruby: 2.6
             rails_version: '6.1.0'
+            ubuntu: '20.04'
 
           # Ruby 2.7
           - ruby: 2.7
             rails_version: '6.1.0'
+            ubuntu: '20.04'
           - ruby: 2.7
             rails_version: '7.0.0'
+            ubuntu: '20.04'
 
           # Ruby 3.0
           - ruby: '3.0'
             rails_version: '6.1.0'
+            ubuntu: '22.04'
           - ruby: '3.0'
             rails_version: '7.0.0'
+            ubuntu: '22.04'
 
           # jruby-9.2
           - ruby: jruby-9.2
             rails_version: '6.0.0'
+            ubuntu: '20.04'
           - ruby: jruby-9.2
             rails_version: '6.1.0'
+            ubuntu: '20.04'
 
           # jruby-9.4
           - ruby: jruby-9.4
             rails_version: '7.0.0'
+            ubuntu: '22.04'
 
           #
           # The past
@@ -51,18 +61,25 @@ jobs:
           # EOL Active Record
           - ruby: 2.2
             rails_version: '3.2.0'
+            ubuntu: '20.04'
           - ruby: 2.1
             rails_version: '4.1.0'
+            ubuntu: '20.04'
           - ruby: 2.4
             rails_version: '4.2.0'
+            ubuntu: '20.04'
           - ruby: 2.4
             rails_version: '5.0.0'
+            ubuntu: '20.04'
           - ruby: 2.5
             rails_version: '5.1.0'
+            ubuntu: '20.04'
           - ruby: 2.6
             rails_version: '5.2.0'
+            ubuntu: '20.04'
           - ruby: 2.7
             rails_version: '6.0.0'
+            ubuntu: '20.04'
 
     continue-on-error: ${{ matrix.rails_version == 'edge' || endsWith(matrix.ruby, 'head') }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     continue-on-error: ${{ matrix.rails_version == 'edge' || endsWith(matrix.ruby, 'head') }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       env:
         RAILS_VERSION: ${{ matrix.rails_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,26 +12,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', jruby-head, ruby-head]
+        ruby: ['3.1', '3.2', '3.3', jruby-head, ruby-head]
         rails_version:
-          - '6.0.0'
           - '6.1.0'
           - '7.0.0'
           - 'edge'
         include:
-          # Rails 5.2
-          - ruby: 2.6
-            rails_version: '5.2.0'
-          - ruby: 2.7
-            rails_version: '5.2.0'
-          - ruby: jruby-9.2
-            rails_version: '5.2.0'
-
           # Ruby 2.6
           - ruby: 2.6
-            rails_version: '6.0.0'
-          - ruby: 2.6
             rails_version: '6.1.0'
+
+          # Ruby 2.7
+          - ruby: 2.7
+            rails_version: '6.1.0'
+          - ruby: 2.7
+            rails_version: '7.0.0'
+
+          # Ruby 3.0
+          - ruby: '3.0'
+            rails_version: '6.1.0'
+          - ruby: '3.0'
+            rails_version: '7.0.0'
 
           # jruby-9.2
           - ruby: jruby-9.2
@@ -42,8 +43,6 @@ jobs:
           # jruby-9.4
           - ruby: jruby-9.4
             rails_version: '7.0.0'
-          - ruby: jruby-9.4
-            rails_version: 'edge'
 
           #
           # The past
@@ -59,6 +58,10 @@ jobs:
             rails_version: '5.0.0'
           - ruby: 2.5
             rails_version: '5.1.0'
+          - ruby: 2.6
+            rails_version: '5.2.0'
+          - ruby: 2.7
+            rails_version: '6.0.0'
 
     continue-on-error: ${{ matrix.rails_version == 'edge' || endsWith(matrix.ruby, 'head') }}
 

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby 2.7
       uses: ruby/setup-ruby@v1
       with:

--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,14 @@ group :test do
     gem 'zeitwerk', :require => false
   end
   gem 'loofah', '< 2.21.0', :require => false if RUBY_VERSION < '2.6'
+
+  # TODO: remove these requires once activesupport has such dependencies
+  # in all versions of Rails we test against on Ruby >=3.4 (and head).
+  if RUBY_VERSION >= '3.4'
+    gem 'base64', :require => false
+    gem 'bigdecimal', :require => false
+    gem 'mutex_m', :require => false
+  end
 end
 
 group :rubocop do

--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :test do
   if ENV['RAILS_VERSION'].nil? || ENV['RAILS_VERSION'] >= '6.0.0'
     gem 'zeitwerk', :require => false
   end
+  gem 'loofah', '< 2.21.0', :require => false if RUBY_VERSION < '2.6'
 end
 
 group :rubocop do

--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -595,7 +595,7 @@ shared_examples_for 'a delayed_job backend' do
         worker.work_off
         @job.reload
         expect(@job.last_error).to match(/did not work/)
-        expect(@job.last_error).to match(/sample_jobs.rb:\d+:in `perform'/)
+        expect(@job.last_error).to match(/sample_jobs.rb:\d+:in [`'](ErrorJob#)?perform'/)
         expect(@job.attempts).to eq(1)
         expect(@job.run_at).to be > Delayed::Job.db_time_now - 10.minutes
         expect(@job.run_at).to be < Delayed::Job.db_time_now + 10.minutes


### PR DESCRIPTION
- Add Ruby 3.3 and Rails 7.1
- Move EOL Rails versions to the lower section, with one build each.
- Introduce a dedicated section for Ruby 2.7 and Ruby 3.0. The next version of Rails won't work with these.
- Specify the Ubuntu version for each build job. Older versions of Ruby segfault on newer versions of Ubuntu.
