### PR TITLE
Address `ActiveSupport::ProxyObject` deprecation on Rails 7.2.0.alpha

### DIFF
--- a/lib/delayed/compatibility.rb
+++ b/lib/delayed/compatibility.rb
@@ -3,24 +3,12 @@ require 'active_support/version'
 module Delayed
   module Compatibility
     if ActiveSupport::VERSION::MAJOR >= 4
-      require 'active_support/proxy_object'
-
       def self.executable_prefix
         'bin'
       end
-
-      def self.proxy_object_class
-        ActiveSupport::ProxyObject
-      end
     else
-      require 'active_support/basic_object'
-
       def self.executable_prefix
         'script'
-      end
-
-      def self.proxy_object_class
-        ActiveSupport::BasicObject
       end
     end
   end

--- a/lib/delayed/message_sending.rb
+++ b/lib/delayed/message_sending.rb
@@ -1,5 +1,5 @@
 module Delayed
-  class DelayProxy < Delayed::Compatibility.proxy_object_class
+  class DelayProxy < BasicObject
     def initialize(payload_class, target, options)
       @payload_class = payload_class
       @target = target


### PR DESCRIPTION
`ActiveSupport::ProxyObject` has been [deprecated](https://github.com/rails/rails/commit/ea7d3c5165d5c7b6d77943482471335d828047ad) on Rails main i.e. `7.2.0.alpha`. The recommended alternative is Ruby's `BasicObject`:

```
Delayed::Compatibility.proxy_object_class
DEPRECATION WARNING: ActiveSupport::ProxyObject is deprecated and will be removed in Rails 7.3.
Use Ruby's buildin BasicObject instead.
 (called from <module:Delayed> at /rails/vendor/bundle/ruby/3.2.0/gems/delayed_job-4.1.11/lib/delayed/message_sending.rb:2)
```

which has been around since Ruby 1.9.

There's some [additional functionality](https://github.com/rails/rails/blob/cc7f0b0d4cabc4807a271a6dfa22150943c80412/activesupport/lib/active_support/proxy_object.rb#L5-L11) that `ActiveSupport::ProxyObject` has over `BasicObject`, but from what I can tell, those aren't being used in this specific case.