### PR TITLE
Update README to mention OSX / run issue in dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,8 @@ You can then do the following:
 
 **Rails 4:** *replace script/delayed_job with bin/delayed_job*
 
+**Note:** `script/delayed_job` / `bin/delayed_job` will hang in development mode on OSX because of an issue with `daemons` and `fsevent_watch` - more information [in the issue here](https://github.com/collectiveidea/delayed_job/issues/935#issuecomment-242171610). 
+
 Workers can be running on any computer, as long as they have access to the
 database and their clock is in sync. Keep in mind that each worker will check
 the database at least every 5 seconds.


### PR DESCRIPTION
There's an existing issue https://github.com/collectiveidea/delayed_job/issues/935 where this is documented - just wanted to add a note to the README mentioning that `bin/delayed_job run` hangs in dev mode on OSX as it might save others some time.