### PR TITLE
Move `ActiveJob` adapter to `delayed_job`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,10 +50,14 @@ group :test do
   if ENV['RAILS_VERSION'] == 'edge'
     gem 'actionmailer', :github => 'rails/rails'
     gem 'activerecord', :github => 'rails/rails'
+    gem 'activejob',    :github => 'rails/rails'
   elsif ENV['RAILS_VERSION']
     gem 'actionmailer', "~> #{ENV['RAILS_VERSION']}"
     gem 'activerecord', "~> #{ENV['RAILS_VERSION']}"
-    if ENV['RAILS_VERSION'] < '5.1'
+
+    if ENV['RAILS_VERSION'] >= '8.0'
+      gem 'activejob', "~> #{ENV['RAILS_VERSION']}" 
+    elsif ENV['RAILS_VERSION'] < '5.1'
       gem 'loofah', '2.3.1'
       gem 'nokogiri', '< 1.11.0'
       gem 'rails-html-sanitizer', '< 1.4.0'

--- a/lib/active_job/queue_adapters/delayed_job_adapter.rb
+++ b/lib/active_job/queue_adapters/delayed_job_adapter.rb
@@ -1,0 +1,60 @@
+if defined?(ActiveJob) && ActiveJob.version >= "8.0.0.alpha"
+  module ActiveJob
+    module QueueAdapters
+      # = Delayed Job adapter for Active Job
+      #
+      # To use Delayed Job, set the queue_adapter config to +:delayed_job+.
+      #
+      #   Rails.application.config.active_job.queue_adapter = :delayed_job
+      class DelayedJobAdapter
+        def initialize(enqueue_after_transaction_commit: false)
+          @enqueue_after_transaction_commit = enqueue_after_transaction_commit
+        end
+
+        def enqueue_after_transaction_commit? # :nodoc:
+          @enqueue_after_transaction_commit
+        end
+
+        def enqueue(job)
+          delayed_job = Delayed::Job.enqueue(JobWrapper.new(job.serialize), queue: job.queue_name, priority: job.priority)
+          job.provider_job_id = delayed_job.id
+          delayed_job
+        end
+
+        def enqueue_at(job, timestamp)
+          delayed_job = Delayed::Job.enqueue(JobWrapper.new(job.serialize), queue: job.queue_name, priority: job.priority, run_at: Time.at(timestamp))
+          job.provider_job_id = delayed_job.id
+          delayed_job
+        end
+
+        class JobWrapper
+          attr_accessor :job_data
+
+          def initialize(job_data)
+            @job_data = job_data
+          end
+
+          def display_name
+            base_name = "#{job_data["job_class"]} [#{job_data["job_id"]}] from DelayedJob(#{job_data["queue_name"]})"
+
+            return base_name unless log_arguments?
+
+            "#{base_name} with arguments: #{job_data["arguments"]}"
+          end
+
+          def perform
+            Base.execute(job_data)
+          end
+
+          private
+            def log_arguments?
+              job_data["job_class"].constantize.log_arguments?
+            rescue NameError
+              false
+            end
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Implements adapter for `ActiveJob` inside the gem. This adapter is defined only if rails version is >=8, for earlier rails versions adapter is defined inside the Rails itself.

I'm not supper familiar with delayed_job internals, this is just a draft if you are interested in doing this I can finish the work on this PR.
This is connected to the discussion here https://github.com/rails/rails/issues/52929

❤️