### PR TITLE
Add support for max_attempts and max_run_time in queue_attributes

### DIFF
--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -287,11 +287,11 @@ module Delayed
     end
 
     def max_attempts(job)
-      job.max_attempts || self.class.max_attempts
+      job.max_attempts || self.class.queue_attributes&.dig(job.queue, :max_attempts) || self.class.max_attempts
     end
 
     def max_run_time(job)
-      job.max_run_time || self.class.max_run_time
+      job.max_run_time || self.class.queue_attributes&.dig(job.queue, :max_run_time) || self.class.max_run_time
     end
 
   protected


### PR DESCRIPTION
This PR suggests adding support for defining `max_attempts` and `max_run_time` in the `queue_attributes`, so that these can be defined per queue. If present, they take precedence over `Delayed::Worker.max_attempts` and `Delayed::Worker.max_run_time` but are overruled by job-specific `max_attempts`. In other words, this is backward-compatible.