### PR TITLE
Change `last_error` to include the exception name

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -47,7 +47,7 @@ module Delayed
       attr_reader :error
       def error=(error)
         @error = error
-        self.last_error = "#{error.message}\n#{error.backtrace.join("\n")}" if respond_to?(:last_error=)
+        self.last_error = "#{error.class.name}: #{error.message}\n#{error.backtrace.join("\n")}" if respond_to?(:last_error=)
       end
 
       def failed?

--- a/lib/delayed/backend/shared_spec.rb
+++ b/lib/delayed/backend/shared_spec.rb
@@ -549,6 +549,7 @@ shared_examples_for 'a delayed_job backend' do
         job = Delayed::Job.create :payload_object => LongRunningJob.new
         worker.run(job)
         expect(job.error).to_not be_nil
+        expect(job.reload.last_error).to match(/\ADelayed::WorkerTimeout: /)
         expect(job.reload.last_error).to match(/expired/)
         expect(job.reload.last_error).to match(/Delayed::Worker\.max_run_time is only 1 second/)
         expect(job.attempts).to eq(1)
@@ -586,6 +587,7 @@ shared_examples_for 'a delayed_job backend' do
         worker.run(@job)
         @job.reload
         expect(@job.error).to_not be_nil
+        expect(@job.last_error).to match(/\AException: /)
         expect(@job.last_error).to match(/did not work/)
         expect(@job.attempts).to eq(1)
         expect(@job).to be_failed


### PR DESCRIPTION
`last_error` did not include the exception class name, so it was sometimes impossible to determine the class name of the exception that occurred.
This PR change `last_error` to include the exception name.