### PR TITLE
Support ActiveJob Continuations

### DIFF
--- a/lib/active_job/queue_adapters/delayed_job_adapter.rb
+++ b/lib/active_job/queue_adapters/delayed_job_adapter.rb
@@ -20,6 +20,10 @@ module ActiveJob
         delayed_job
       end
 
+      def stopping?
+        Delayed::Worker.stop?
+      end
+
       class JobWrapper
         attr_accessor :job_data
 

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -53,7 +53,7 @@ module Delayed
     # (perhaps to inspect the reason for the failure), set this to false.
     self.destroy_failed_jobs = true
 
-    # By default, Signals INT and TERM set @exit, and the worker exits upon completion of the current job.
+    # By default, Signals INT and TERM set @@exit, and the worker exits upon completion of the current job.
     # If you would prefer to raise a SignalException and exit immediately you can use this.
     # Be aware daemons uses TERM to stop and restart
     # false - No exceptions will be raised
@@ -196,12 +196,20 @@ module Delayed
       end
     end
 
-    def stop
+    def self.stop
       @exit = true
     end
 
-    def stop?
+    def stop
+      self.class.stop
+    end
+
+    def self.stop?
       !!@exit
+    end
+
+    def stop?
+      self.class.stop?
     end
 
     # Do num jobs and return stats on success/failure.

--- a/spec/active_job_adapter_spec.rb
+++ b/spec/active_job_adapter_spec.rb
@@ -107,4 +107,12 @@ describe 'a Rails active job backend' do
 
     expect(JobBuffer.values).to eq(%w[2 1])
   end
+
+  it 'adapter stopping? reflects worker stop?' do
+    adapter = ActiveJob::QueueAdapters::DelayedJobAdapter.new
+
+    expect(adapter.stopping?).to eq(false)
+    worker.stop
+    expect(adapter.stopping?).to eq(true)
+  end
 end


### PR DESCRIPTION
Converted stop and stop? methods on Delayed::Worker to class methods and override the stopping? method on the ActiveJob adapter. This now checks if the worker has been stopped and allow jobs to save a checkout and stop.